### PR TITLE
Fix buffer error when converting lines to Shapely

### DIFF
--- a/gplately/geometry.py
+++ b/gplately/geometry.py
@@ -190,8 +190,6 @@ def pygplates_to_shapely(
     for i in wrapped:
         if isinstance(i, pygplates.DateLineWrapper.LatLonPolyline):
             tmp = _LineString([j.to_lat_lon()[::-1] for j in i.get_points()])
-            if validate:
-                tmp = tmp.buffer(0.0)
             output_geoms.append(tmp)
             output_type = _MultiLineString
         elif isinstance(i, pygplates.DateLineWrapper.LatLonPolygon):


### PR DESCRIPTION
This error caused `pygplates_to_shapely` to fail when converting lines with the parameter `validate=True`, as the lines were wrongly converted to zero-area polygons.