### PR TITLE
Fix projected subduction teeth error

### DIFF
--- a/gplately/plot.py
+++ b/gplately/plot.py
@@ -497,6 +497,10 @@ def plot_subduction_teeth(
             transform,
         )
 
+    if projection is not None:
+        domain = projection.domain
+        triangles = [domain.intersection(i) for i in triangles]
+
     if hasattr(ax, "add_geometries") and projection is not None:
         ax.add_geometries(triangles, crs=projection, **kwargs)
     else:


### PR DESCRIPTION
This fix should prevent an error that was occasionally showing up
when plotting subduction teeth on the edges of a projected map.