### PR TITLE
Add raster reconstruction capabilities

### DIFF
--- a/gplately/geometry.py
+++ b/gplately/geometry.py
@@ -173,6 +173,8 @@ def pygplates_to_shapely(
 
     if isinstance(geometry, pygplates.LatLonPoint):
         geometry = geometry.to_point_on_sphere()
+    if isinstance(geometry, pygplates.ReconstructedFeatureGeometry):
+        geometry = geometry.get_reconstructed_geometry()
     if not isinstance(geometry, pygplates.GeometryOnSphere):
         raise TypeError("Invalid geometry type: " + str(type(geometry)))
 
@@ -474,17 +476,25 @@ def _contains_shapely_geometries(i):
     return False
 
 
+def _is_pygplates_geometry(geom):
+    return isinstance(
+        geom,
+        (
+            pygplates.GeometryOnSphere,
+            pygplates.LatLonPoint,
+            pygplates.ReconstructedFeatureGeometry,
+        ),
+    )
+
+
 def _contains_pygplates_geometries(i):
     """Check if input is an iterable containing only PyGPlates geometries."""
-    is_pygplates_geometry = lambda x: isinstance(
-        x, (pygplates.GeometryOnSphere, pygplates.LatLonPoint)
-    )
-    if is_pygplates_geometry(i):
+    if _is_pygplates_geometry(i):
         return False
     try:
         # Check all elements in i are PyGPlates geometries
         for j in i:
-            if not is_pygplates_geometry(j):
+            if not _is_pygplates_geometry(j):
                 break
         else:
             return True

--- a/gplately/grids.py
+++ b/gplately/grids.py
@@ -10,11 +10,24 @@ RegularGridInterpolator
 Raster
 TimeRaster
 """
+import concurrent.futures
+from multiprocessing import cpu_count
+import tempfile
+import os
+import warnings
+
+import pygplates
+from geocube.api.core import make_geocube
+import geopandas as gpd
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator as _RGI
-from scipy.ndimage import distance_transform_edt
+from scipy.ndimage import distance_transform_edt, map_coordinates
+from shapely.geometry import box
+from skimage.transform import resize
+
 from .reconstruction import Points as _Points
 from .tools import EARTH_RADIUS as _EARTH_RADIUS
+
 
 def fill_raster(data,invalid=None):
     """Searches grid for invalid ‘data’ cells containing NaN-type entries (as indicated by ‘invalid’), locates the index 
@@ -356,6 +369,618 @@ def sample_grid(lon, lat, grid, extent=[-180,180,-90,90], return_indices=False, 
     return interpolator(np.c_[lat, lon], return_indices=return_indices, return_distances=return_distances)
 
 
+
+def reconstruct_grid(
+    grid,
+    partitioning_features,
+    rotation_model,
+    to_time,
+    from_time=0.0,
+    extent="global",
+    origin="upper",
+    plate_ids=None,
+    threads=1,
+):
+    """Reconstruct a gridded dataset to a given reconstruction time.
+
+    Parameters
+    ----------
+    grid : array_like, or str
+        The grid to be reconstructed. If `grid` is a filename, it will be
+        loaded using `gplately.grids.read_netcdf_grid`.
+    partitioning_features : valid argument to pygplates.FeaturesFunctionArgument
+        Features used to partition `grid` by plate ID, usually a static
+        polygons file. `partitioning_features` may be a single
+        feature (`pygplates.Feature`), a feature collection
+        (`pygplates.FeatureCollection`), a filename (`str`), or a (potentially
+        nested) sequence of any combination of the above types.
+    rotation_model : valid argument to pygplates.RotationModel
+        The rotation model used to reconstruct `grid`.
+        `rotation_model` may be a rotation model object
+        (`pygplates.RotationModel`), a rotation feature collection
+        (`pygplates.FeatureCollection`), a rotation filename
+        (`str`), a rotation feature (`pygplates.Feature`), a sequence of
+        rotation features, or a (potentially nested) sequence of any
+        combination of the above types.
+    to_time : float
+        Time to which `grid` will be reconstructed.
+    from_time : float, default 0.0
+        Time from which to reconstruct `grid`.
+    extent : tuple or "global", default "global"
+        Extent of `grid`. Valid arguments are a tuple of
+        the form (xmin, xmax, ymin, ymax), or the string "global",
+        equivalent to (-180.0, 180.0, -90.0, 90.0).
+    origin : {"upper", "lower"}
+        Origin of `grid` - either lower-left or upper-left.
+    plate_ids : array_like, optional
+        If a rasterised grid of plate IDs has already been obtained
+        (e.g. using `gplately.grids.rasterise`), it can be provided here
+        in order to avoid repeatedly rasterising `partitioning_features`.
+        `plate_ids` must be of the same shape as `grid`.
+    threads : int, default 1
+        Number of threads to use for certain computationally heavy subroutines.
+
+    Returns
+    -------
+    numpy.ndarray
+        The reconstructed grid. Areas for which no plate ID could be obtained
+        from `partitioning_features` will be filled with either `-1` or
+        `np.nan`, depending on the dtype of `grid`.
+    """
+    try:
+        grid = np.array(read_netcdf_grid(grid))
+    except Exception:
+        pass
+    if to_time == from_time:
+        return grid
+    if plate_ids is not None:
+        plate_ids = np.array(plate_ids)
+    if plate_ids is not None and plate_ids.shape != grid.shape:
+        raise ValueError(
+            "Shape mismatch: "
+            + "`grid.shape` == {}, ".format(grid.shape)
+            + "`plate_ids.shape` == {}".format(plate_ids.shape)
+        )
+    if origin.lower() not in {"lower", "upper"}:
+        raise ValueError("Invalid `origin` value: {}".format(origin))
+    origin = origin.lower()
+    dtype = grid.dtype
+    if dtype.kind in ("b", "u"):
+        grid = grid.astype(int)
+        dtype = grid.dtype
+
+    if isinstance(threads, str):
+        if threads.lower() in {"all", "max"}:
+            threads = cpu_count()
+        else:
+            raise ValueError("Invalid `threads` value: {}".format(threads))
+    threads = min([int(threads), cpu_count()])
+    threads = max([threads, 1])
+
+    grid = grid.squeeze()
+    if grid.ndim != 2:
+        raise ValueError("`grid` has invalid shape {}".format(grid.shape))
+    if extent == "global":
+        extent = (-180, 180, -90, 90)
+    xmin, xmax, ymin, ymax = extent
+    if xmin > xmax:
+        xmin, xmax = xmax, xmin
+    if ymin > ymax:
+        ymin, ymax = ymax, ymin
+    ny, nx = grid.shape
+    resx = (xmax - xmin) / nx
+    resy = (ymax - ymin) / ny
+
+    if not isinstance(partitioning_features, pygplates.FeatureCollection):
+        partitioning_features = pygplates.FeatureCollection(
+            pygplates.FeaturesFunctionArgument(
+                partitioning_features
+            ).get_features()
+        )
+    if not isinstance(rotation_model, pygplates.RotationModel):
+        rotation_model = pygplates.RotationModel(rotation_model)
+
+    lats = np.arange(ymin + resy * 0.5, ymax, resy)
+    lons = np.arange(xmin + resx * 0.5, xmax, resx)
+    lons, lats = np.meshgrid(lons, lats)
+    if plate_ids is None:
+        plate_ids = rasterise(
+            features=partitioning_features,
+            rotation_model=rotation_model,
+            key="PLATEID1",
+            resx=resx,
+            resy=resy,
+            time=to_time,
+            extent=extent,
+            shape=grid.shape,
+        ).flatten()
+    else:
+        plate_ids = plate_ids.flatten()
+
+    unique_plate_ids = np.unique(plate_ids)
+    rotations_dict = {}
+    for plate in unique_plate_ids:
+        if plate == -1:
+            continue
+        rot = rotation_model.get_rotation(
+            float(from_time),
+            int(plate),
+            float(to_time),
+        )
+        if not isinstance(rot, pygplates.FiniteRotation):
+            continue
+        lat, lon, angle = rot.get_lat_lon_euler_pole_and_angle_degrees()
+        angle = np.deg2rad(angle)
+        vec = _lat_lon_to_vector(lat, lon, degrees=True)
+        rotations_dict[plate] = (vec, angle)
+
+    point_vecs = _lat_lon_to_vector(
+        lats,
+        lons,
+        degrees=True,
+        threads=threads,
+    )
+
+    rotated_vecs = np.full_like(point_vecs, np.nan)
+    if threads > 1:
+        executor = concurrent.futures.ThreadPoolExecutor(threads)
+        plate_ids_divided = np.array_split(unique_plate_ids, threads)
+
+        def _fill(ids, out):
+            for id in ids:
+                if id == -1:
+                    continue
+                index = plate_ids == id
+                vec_subset = point_vecs[index, :]
+                rotation, angle = rotations_dict[id]
+                rotated = _rotate(vec_subset, rotation, angle)
+                out[index] = rotated
+
+        futures = {}
+        for i in range(threads):
+            args = (
+                _fill,
+                plate_ids_divided[i],
+                rotated_vecs,
+            )
+            futures[executor.submit(*args)] = i
+        concurrent.futures.wait(futures)
+        executor.shutdown(False)
+    else:
+        for plate_id in unique_plate_ids:
+            if plate_id == -1:
+                continue
+            index = plate_ids == plate_id
+            vec_subset = point_vecs[index, :]
+            rotation, angle = rotations_dict[plate_id]
+            rotated = _rotate(vec_subset, rotation, angle)
+            rotated_vecs[index] = rotated
+
+    x = rotated_vecs[:, 0]
+    y = rotated_vecs[:, 1]
+    z = rotated_vecs[:, 2]
+    rotated_lats, rotated_lons = _vector_to_lat_lon(
+        x,
+        y,
+        z,
+        degrees=True,
+        return_array=True,
+        threads=threads,
+    )
+    if origin == "upper":
+        rotated_y = (ymax - rotated_lats) / resy
+    else:
+        rotated_y = (rotated_lats - ymin) / resy
+    rotated_x = np.abs((rotated_lons - xmin) / resx)
+
+    mask = plate_ids != -1
+    interp_coords = np.vstack(
+        (
+            rotated_y.reshape((1, -1)),
+            rotated_x.reshape((1, -1)),
+        )
+    )
+    # data = np.full(rotated_lats.size, np.nan)
+    if dtype.kind == "i":
+        fill_value = -1
+    elif dtype.kind in ("f", "c"):
+        fill_value = np.nan
+    else:
+        fill_value = np.nan
+    data = np.full(rotated_lats.size, fill_value, dtype=dtype)
+    tmp = map_coordinates(
+        grid,
+        interp_coords[:, mask],
+        mode="grid-wrap",
+        order=0,
+    ).squeeze()
+    data[mask] = tmp
+    data = data.reshape(grid.shape)
+    if origin == "upper":
+        data = np.flipud(data)
+    return data
+
+
+def rasterise(
+    features,
+    rotation_model=None,
+    key="PLATEID1",
+    time=0.0,
+    resx=1.0,
+    resy=1.0,
+    extent="global",
+    shape=None,
+):
+    """Rasterise GPlates objects at a given reconstruction time.
+
+    This function is particularly useful for rasterising static polygons
+    to extract a grid of plate IDs.
+
+    Parameters
+    ----------
+    features : valid argument for pygplates.FeaturesFunctionArgument
+        `features` may be a single `pygplates.Feature`, a
+        `pygplates.FeatureCollection`, a `str` filename,
+        or a (potentially nested) sequence of any combination of the
+        above types.
+    rotation_model : valid argument for pygplates.RotationModel, optional
+        `rotation_model` may be a `pygplates.RotationModel`, a rotation
+        feature collection (pygplates.FeatureCollection), a rotation filename
+        (`str`), a rotation feature (`pygplates.Feature`), a sequence of
+        rotation features, or a (potentially nested) sequence of any
+        combination of the above types.
+        Alternatively, if time == 0 (present-day), a rotation model is
+        not usually required.
+    key : str, default "PLATEID1"
+        `key` may be any one of the following values:
+        "PLATEID1" (plate ID),
+        "PLATEID2" (conjugate plate ID),
+        "FROMAGE" (time of appearance),
+        "TOAGE" (time of disappearance),
+        "L_PLATE" (left plate ID),
+        "R_PLATE" (right plate ID),
+        "SPREAD_ASY" (spreading asymmetry),
+        "IMPORT_AGE" (time of geometry import)
+    time : float, default 0.0
+        Reconstruction time at which to perform rasterisation.
+    resx, resy : float, default 1.0
+        Resolution (in degrees) of the rasterised grid.
+    extent : tuple or "global", default "global"
+        Extent of the rasterised grid. Valid arguments are a tuple of
+        the form (xmin, xmax, ymin, ymax), or the string "global",
+        equivalent to (-180.0, 180.0, -90.0, 90.0).
+    shape : tuple, optional
+        If given, force the output grid to have the specified shape.
+        The result will potentially be padded or shrunk accordingly.
+
+    Returns
+    -------
+    grid : numpy.ndarray
+        The output array will have the shape specified in `shape`, if given.
+        The origin of the array will be in the lower-left corner of
+        the area specified in `extent`, unless `resx` or `resy` is negative.
+
+    Raises
+    ------
+    ValueError
+        If an invalid `key` value is passed, or if `rotation_model` is not
+        supplied and `time` != 0.0.
+
+    Notes
+    -----
+    This function is used by gplately.grids.reconstruct_grids to rasterise
+    static polygons, extracting their plate IDs.
+    """
+    # Valid numerical values are as follows
+    # N.B. only PLATEID1, TOAGE, and FROMAGE values
+    # are particularly meaningful
+    valid_keys = {
+        "PLATEID1",
+        "TOAGE",
+        "FROMAGE",
+        "PLATEID2",
+        "L_PLATE",
+        "R_PLATE",
+        "SPREAD_ASY",
+        "IMPORT_AGE",
+    }
+    key_dtypes = {
+        "PLATEID1": int,
+        "TOAGE": float,
+        "FROMAGE": float,
+        "PLATEID2": int,
+        "L_PLATE": int,
+        "R_PLATE": int,
+        "SPREAD_ASY": float,
+        "IMPORT_AGE": float,
+    }
+    if key not in valid_keys:
+        raise ValueError(
+            "`key` must be one of the following:" + "{}".format(valid_keys)
+        )
+    if extent == "global":
+        extent = (-180.0, 180.0, -90.0, 90.0)
+    if extent[1] < extent[0]:
+        extent = (extent[1], extent[0], extent[2], extent[3])
+    if extent[3] < extent[2]:
+        extent = (extent[0], extent[1], extent[3], extent[2])
+    features = pygplates.FeaturesFunctionArgument(features).get_features()
+    time = float(time)
+    if rotation_model is None:
+        if time != 0.0:
+            raise ValueError(
+                "If `rotation_model` is not provided, `time` must not"
+                + " be zero ({} != 0)".format(time)
+            )
+        rotation_model = pygplates.RotationModel(pygplates.Feature())
+    else:
+        rotation_model = pygplates.RotationModel(rotation_model)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = os.path.join(tmpdir, "{}.shp".format(time))
+        pygplates.reconstruct(
+            features,
+            rotation_model,
+            out,
+            float(time),
+        )
+        if not os.path.isfile(out):
+            out = os.path.join(
+                tmpdir,
+                "{}".format(time),
+                "{}_polygon.shp".format(time),
+            )
+        gdf = gpd.read_file(out)
+    # This step could raise problems, as GPlates often produces
+    # geometries which are technically invalid and thus
+    # cause geometric operations like clip to fail
+    if extent is not None and extent != (-180, 180, -90, 90):
+        gdf = gpd.clip(
+            gdf,
+            box(extent[0], extent[2], extent[1], extent[3]),
+        )
+    dtype = key_dtypes[key]
+    if dtype is int:
+        fill_value = -1
+    else:
+        fill_value = np.nan
+    gdf[key] = gdf[key].astype(dtype)
+
+    dset = make_geocube(
+        gdf,
+        [key],
+        resolution=(resy, resx),
+        fill=fill_value,
+        align=(np.abs(resy) * 0.5, np.abs(resx) * 0.5),
+    )
+    data = dset[key]
+
+    if extent is None or shape is None or data.shape == shape:
+        return np.array(data, dtype=dtype)
+
+    size = shape[0] * shape[1]
+    if data.size < size:
+        # Often we need to pad the result of make_geocube by
+        # one or two rows or columns
+        dset_extent = (
+            float(dset["x"].min()),
+            float(dset["x"].max()),
+            float(dset["y"].min()),
+            float(dset["y"].max()),
+        )
+        pad_left = int(np.abs((dset_extent[0] - extent[0]) / resx))
+        pad_right = int(np.abs((dset_extent[1] - extent[1] + 1) / resx))
+        pad_bottom = int(np.abs((dset_extent[2] - extent[2]) / resy))
+        pad_top = int(np.abs((dset_extent[3] - extent[3] + 1) / resy))
+        data = data.pad(
+            {
+                "x": (pad_left, pad_right),
+                "y": (pad_bottom, pad_top),
+            },
+            constant_values=fill_value,
+        )
+
+    data = np.array(data, dtype=dtype)
+    data = resize(
+        data,
+        shape,
+        order=0,
+        mode="wrap",
+        preserve_range=True,
+    )
+    return data
+
+
+rasterize = rasterise
+
+
+def _lat_lon_to_vector(lat, lon, degrees=False, threads=1):
+    """Convert (lat, lon) coordinates (degrees or radians) to vectors on
+    the unit sphere. Returns a vector of shape (3,) if `lat` and `lon` are
+    single values, else an array of shape (N, 3) containing N (x, y, z)
+    row vectors, where N is the size of `lat` and `lon`.
+    """
+    lon = np.atleast_1d(lon).flatten()
+    lat = np.atleast_1d(lat).flatten()
+    if degrees:
+        lat = np.deg2rad(lat)
+        lon = np.deg2rad(lon)
+
+    if threads == 1:
+        x = np.cos(lat) * np.cos(lon)
+        y = np.cos(lat) * np.sin(lon)
+        z = np.sin(lat)
+    else:
+        n = lat.size
+        step = np.ceil(n / threads).astype(np.int_)
+        executor = concurrent.futures.ThreadPoolExecutor(threads)
+
+        def _fill(out_x, out_y, out_z, first, last):
+            np.multiply(
+                np.cos(lat[first:last]),
+                np.cos(lon[first:last]),
+                out=out_x[first:last],
+            )
+            np.multiply(
+                np.cos(lat[first:last]),
+                np.sin(lon[first:last]),
+                out=out_y[first:last],
+            )
+            np.sin(lat[first:last], out=out_z[first:last])
+
+        futures = {}
+        x = np.zeros_like(lat)
+        y = np.zeros_like(x)
+        z = np.zeros_like(x)
+        for i in range(threads):
+            args = (
+                _fill,
+                x,
+                y,
+                z,
+                i * step,
+                (i + 1) * step,
+            )
+            futures[executor.submit(*args)] = i
+        concurrent.futures.wait(futures)
+        executor.shutdown(False)
+
+    size = x.size
+    if size == 1:
+        x = np.atleast_1d(np.squeeze(x))[0]
+        y = np.atleast_1d(np.squeeze(y))[0]
+        z = np.atleast_1d(np.squeeze(z))[0]
+        return np.array((x, y, z))
+
+    x = x.reshape((-1, 1))
+    y = y.reshape((-1, 1))
+    z = z.reshape((-1, 1))
+    return np.hstack((x, y, z))
+
+
+def _vector_to_lat_lon(
+    x,
+    y,
+    z,
+    degrees=False,
+    return_array=False,
+    threads=1,
+):
+    """Convert one or more (x, y, z) vectors (on the unit sphere) to
+    (lat, lon) coordinate pairs, in degrees or radians. Optionally, use
+    more than one thread.
+    """
+    x = np.atleast_1d(x).flatten()
+    y = np.atleast_1d(y).flatten()
+    z = np.atleast_1d(z).flatten()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        if threads == 1:
+            lat = np.arcsin(z)
+            lon = np.arctan2(y, x)
+            if degrees:
+                lat = np.rad2deg(lat)
+                lon = np.rad2deg(lon)
+        else:
+            n = x.size
+            step = np.ceil(n / threads).astype(np.int_)
+            executor = concurrent.futures.ThreadPoolExecutor(threads)
+
+            def _fill(out_lat, out_lon, first, last, degrees=False):
+                if degrees:
+                    np.rad2deg(
+                        np.arcsin(z[first:last]),
+                        out=out_lat[first:last],
+                    )
+                    np.rad2deg(
+                        np.arctan2(
+                            y[first:last],
+                            x[first:last],
+                        ),
+                        out=out_lon[first:last],
+                    )
+                else:
+                    np.arcsin(z[first:last], out=out_lat[first:last])
+                    np.arctan2(
+                        y[first:last],
+                        x[first:last],
+                        out=out_lon[first:last],
+                    )
+
+            futures = {}
+            lat = np.zeros_like(x)
+            lon = np.zeros_like(lat)
+            for i in range(threads):
+                args = (
+                    _fill,
+                    lat,
+                    lon,
+                    i * step,
+                    (i + 1) * step,
+                    degrees,
+                )
+                futures[executor.submit(*args)] = i
+            concurrent.futures.wait(futures)
+            executor.shutdown(False)
+
+    if lat.size == 1 and not return_array:
+        lat = np.atleast_1d(np.squeeze(lat))[0]
+        lon = np.atleast_1d(np.squeeze(lon))[0]
+        return (lat, lon)
+
+    lat = lat.reshape((-1, 1))
+    lon = lon.reshape((-1, 1))
+    return lat, lon
+
+
+def _rotate(vectors, rotation, angle):
+    cross = _cross_products
+    dot = np.dot
+
+    invalid_dims_err = ValueError(
+        "Invalid shapes: {}, {}".format(vectors.shape, rotation.shape)
+    )
+    vectors = np.atleast_2d(vectors)
+    rotation = np.squeeze(rotation)
+    if vectors.shape[1] != 3:
+        vectors = vectors.T
+    if vectors.shape[1] != 3 or rotation.shape != (3,):
+        raise invalid_dims_err
+
+    angle = float(angle)
+
+    t1 = np.cos(angle) * vectors
+    t2 = np.sin(angle) * cross(rotation, vectors)
+    t3 = (
+        (1.0 - np.cos(angle))
+        * dot(vectors, rotation.reshape((-1, 1))).reshape((-1, 1))
+        * vectors
+    )
+    return t1 + t2 + t3
+
+
+def _cross_products(a, b):
+    """Cross products of a vector and a list of vectors."""
+    if a.ndim == 2 and b.ndim == 1:
+        return -1.0 * _cross_products(b, a)
+    vec = a
+    arr = b
+    invalid_dims_err = ValueError(
+        "Invalid dimensions: {}, {}".format(vec.ndim, arr.ndim)
+    )
+    if vec.ndim != 1 or arr.ndim != 2:
+        raise invalid_dims_err
+
+    if arr.shape[1] != 3:
+        arr = arr.T
+    if arr.shape[1] != 3:
+        raise invalid_dims_err
+
+    out = np.zeros_like(arr)
+    out[:, 0] = vec[1] * arr[:, 2] - vec[2] * arr[:, 1]
+    out[:, 1] = vec[2] * arr[:, 0] - vec[0] * arr[:, 2]
+    out[:, 2] = vec[0] * arr[:, 1] - vec[1] * arr[:, 0]
+    return out
 
 
 class Raster(object):

--- a/gplately/grids.py
+++ b/gplately/grids.py
@@ -25,6 +25,19 @@ from scipy.ndimage import distance_transform_edt, map_coordinates
 from .geometry import pygplates_to_shapely
 from .reconstruction import Points as _Points
 
+__all__ = [
+    "fill_raster",
+    "read_netcdf_grid",
+    "write_netcdf_grid",
+    "RegularGridInterpolator",
+    "sample_grid",
+    "reconstruct_grid",
+    "rasterise",
+    "rasterize",
+    "Raster",
+    "TimeRaster",
+]
+
 
 def fill_raster(data,invalid=None):
     """Searches grid for invalid ‘data’ cells containing NaN-type entries (as indicated by ‘invalid’), locates the index 
@@ -183,7 +196,6 @@ def write_netcdf_grid(filename, grid, extent=[-180,180,-90,90]):
 
         cdf_data = cdf.createVariable('z', grid.dtype, ('y','x'), zlib=True)
         cdf_data[:,:] = grid
-
 
 
 class RegularGridInterpolator(_RGI):
@@ -364,7 +376,6 @@ def sample_grid(lon, lat, grid, extent=[-180,180,-90,90], return_indices=False, 
                                             grid, method=method)
 
     return interpolator(np.c_[lat, lon], return_indices=return_indices, return_distances=return_distances)
-
 
 
 def reconstruct_grid(
@@ -1298,9 +1309,6 @@ class Raster(object):
         zi[angles.ravel() > rxy] = np.nan
         zi = zi.reshape(lonq.shape)
         return zi
-
-
-
 
 
 class TimeRaster(Raster):

--- a/setup.py
+++ b/setup.py
@@ -88,8 +88,9 @@ if __name__ == "__main__":
                                'cartopy',
                                'PlateTectonicTools',
                                'pooch',
-                               'tqdm'
-                               "netcdf4",
+                               'tqdm',
+                               'netcdf4',
+                               'rasterio',
                                ],
           packages          = ['gplately'],
           package_data      = {'gplately': ['Notebooks/*ipynb', # Worked Examples is not currently used

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ if __name__ == "__main__":
                                'tqdm',
                                'netcdf4',
                                'rasterio',
+                               'geopandas',
                                ],
           packages          = ['gplately'],
           package_data      = {'gplately': ['Notebooks/*ipynb', # Worked Examples is not currently used

--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,10 @@ if __name__ == "__main__":
                                'shapely',
                                'matplotlib',
                                'cartopy',
-                               'geopandas',
                                'PlateTectonicTools',
                                'pooch',
                                'tqdm'
+                               "netcdf4",
                                ],
           packages          = ['gplately'],
           package_data      = {'gplately': ['Notebooks/*ipynb', # Worked Examples is not currently used


### PR DESCRIPTION
Raster reconstruction currently works best when reconstructing global rasters backwards in time. Forward (reverse) reconstruction still has some issues with distortion of the original raster, which can be seen when reconstructing a present-day raster backwards and then forwards in time.

In the images below, global topography was reconstructed to 50 Ma and then back to the present:
![original_0Ma](https://user-images.githubusercontent.com/60722740/154224899-52d8e95a-cf6c-44f7-ab90-385ee883d6ac.png)
![reverse_reconstructed_50Ma](https://user-images.githubusercontent.com/60722740/154224909-70632a60-6ce0-436a-895c-0a06ecb3cf5f.png)
 