### PR TITLE
Clennett et al. 2020

### DIFF
--- a/gplately/data.py
+++ b/gplately/data.py
@@ -65,6 +65,21 @@ class DataCollection(object):
         return links_to_download
 
 
+    def netcdf4_spreading_rate_grids(self, time):
+
+        spread_grid_links = {
+
+            "Clennett2020" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Clennett_etal_2020_G3/Clennett_etal_2020_SpreadRate_Grids/rategrid_final_mask_{}.nc"]
+        }
+
+        links_to_download = _find_needed_collection(
+            self.file_collection, 
+            spread_grid_links,
+            time)
+
+        return links_to_download
+
+        
     def plate_reconstruction_files(self):
 
         database = {
@@ -72,7 +87,7 @@ class DataCollection(object):
             "Cao2020" : ["https://zenodo.org/record/3854549/files/1000Myr_synthetic_tectonic_reconstructions.zip"],
             "Muller2019" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Muller_etal_2019_Tectonics/Muller_etal_2019_PlateMotionModel/Muller_etal_2019_PlateMotionModel_v2.0_Tectonics_Updated.zip"], 
             "Muller2016" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Muller_etal_2016_AREPS/Muller_etal_2016_AREPS_Supplement/Muller_etal_2016_AREPS_Supplement_v1.17.zip"],
-            "Mather2021" : ["https://zenodo.org/record/5769002/files/plate_model.zip"],
+            "Clennett2020" : ["https://zenodo.org/record/5769002/files/plate_model.zip"],
             "Seton2012" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Seton_etal_2012_ESR.zip"],
             "Merdith2021" : ["https://zenodo.org/record/4485738/files/SM2_4485738_V2.zip"],
             "Matthews2016" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Matthews_etal_2016_Global_Plate_Model_GPC.zip"], 
@@ -98,7 +113,7 @@ class DataCollection(object):
             "Cao2020" : [1000],
             "Muller2019" : [250], 
             "Muller2016" : [240],
-            "Mather2021" : [170],
+            "Clennett2020" : [170],
             "Seton2012" : [200],
             "Merdith2021" : [1000],
             "Matthews2016" : [410], 
@@ -195,7 +210,7 @@ class DataCollection(object):
             "Cao2020" : ["https://zenodo.org/record/3854549/files/1000Myr_synthetic_tectonic_reconstructions.zip"],
             "Muller2019" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Muller_etal_2019_Tectonics/Muller_etal_2019_PlateMotionModel/Muller_etal_2019_PlateMotionModel_v2.0_Tectonics_Updated.zip"], 
             "Muller2016" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Muller_etal_2016_AREPS/Muller_etal_2016_AREPS_Supplement/Muller_etal_2016_AREPS_Supplement_v1.17.zip"],
-            "Mather2021" : ["https://zenodo.org/record/5769002/files/plate_model.zip"],
+            "Clennett2020" : ["https://zenodo.org/record/5769002/files/plate_model.zip"],
             "Seton2012" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Seton_etal_2012_ESR.zip"],
             "Merdith2021" : ["https://zenodo.org/record/4485738/files/SM2_4485738_V2.zip"],
             "Matthews2016" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Matthews_etal_2016_Global_Plate_Model_GPC.zip"], 

--- a/gplately/data.py
+++ b/gplately/data.py
@@ -87,7 +87,7 @@ class DataCollection(object):
             "Cao2020" : ["https://zenodo.org/record/3854549/files/1000Myr_synthetic_tectonic_reconstructions.zip"],
             "Muller2019" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Muller_etal_2019_Tectonics/Muller_etal_2019_PlateMotionModel/Muller_etal_2019_PlateMotionModel_v2.0_Tectonics_Updated.zip"], 
             "Muller2016" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Muller_etal_2016_AREPS/Muller_etal_2016_AREPS_Supplement/Muller_etal_2016_AREPS_Supplement_v1.17.zip"],
-            "Clennett2020" : ["https://zenodo.org/record/5769002/files/plate_model.zip"],
+            "Clennett2020" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Clennett_etal_2020_G3/Global_Model_WD_Internal_Release_2019_v2_Clennett_NE_Pacific.zip"],
             "Seton2012" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Seton_etal_2012_ESR.zip"],
             "Merdith2021" : ["https://zenodo.org/record/4485738/files/SM2_4485738_V2.zip"],
             "Matthews2016" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Matthews_etal_2016_Global_Plate_Model_GPC.zip"], 
@@ -137,6 +137,7 @@ class DataCollection(object):
             "OLD",
             "__MACOSX",
             "DO_NOT",
+            "Blocks_crossing_Poles"
         ]    
         return strings
 
@@ -160,6 +161,20 @@ class DataCollection(object):
             "Feature_Geometries",
             "boundaries",
             "Clennett_etal_2020_Plates", # For Clennett 2020 (M2019)
+            "Clennett_2020_Plates", # For topologies in Clennett et al 2020 (Pacific)
+            "Clennett_2020_Terranes", # For topologies in Clennett et al 2020 (Pacific)
+            "Angayucham",
+            "Farallon",
+            "Guerrero",
+            "Insular",
+            "Intermontane",
+            "Kula",
+            "North_America",
+            "South_America",
+            "Western_Jurassic",
+            "Clennett_2020_Isochrons",
+            "Clennett_2020_Coastlines",
+            "Clennett_2020_NAm_boundaries",
 
         ]
         return strings 
@@ -171,6 +186,9 @@ class DataCollection(object):
             "OLD",
             "__MACOSX",
             "DO_NOT",
+            "9_Point_Density", # Clennett et al 2020
+            "Density", # Clennett et al 2020
+            "Inactive_Meshes_and_Topologies", # Clennett et al 2020
         ]
         return strings
 
@@ -178,11 +196,11 @@ class DataCollection(object):
     def static_polygon_strings_to_include(self):
 
         strings = [
-            "Static",
             "StaticPolygon",
             "Static_Polygon",
+            "StaticPlatePolygons_",
             "RodiniaBlocks_WithPlateIDColumnAndIDs",
-            "PlatePolygons.shp",
+            # "PlatePolygons.shp",
             "CEED6_TERRANES.shp",
             "CEED6_MICROCONTINENTS.shp",
             "CEED6_LAND.gpml",
@@ -198,7 +216,9 @@ class DataCollection(object):
 
             "DO_NOT",
             "OLD",
-            "__MACOSX"
+            "__MACOSX",
+            "Global_Model_WD_Internal_Release_2019_v2_Clennett_NE_Pacific/StaticGeometries/StaticPolygons/Global_EarthByte_GPlates_PresentDay_StaticPlatePolygons.shp" # Clennett 2020
+
         ]
         return strings
 
@@ -210,7 +230,7 @@ class DataCollection(object):
             "Cao2020" : ["https://zenodo.org/record/3854549/files/1000Myr_synthetic_tectonic_reconstructions.zip"],
             "Muller2019" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Muller_etal_2019_Tectonics/Muller_etal_2019_PlateMotionModel/Muller_etal_2019_PlateMotionModel_v2.0_Tectonics_Updated.zip"], 
             "Muller2016" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Muller_etal_2016_AREPS/Muller_etal_2016_AREPS_Supplement/Muller_etal_2016_AREPS_Supplement_v1.17.zip"],
-            "Clennett2020" : ["https://zenodo.org/record/5769002/files/plate_model.zip"],
+            "Clennett2020" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Clennett_etal_2020_G3/Global_Model_WD_Internal_Release_2019_v2_Clennett_NE_Pacific.zip"],
             "Seton2012" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Seton_etal_2012_ESR.zip"],
             "Merdith2021" : ["https://zenodo.org/record/4485738/files/SM2_4485738_V2.zip"],
             "Matthews2016" : ["https://www.earthbyte.org/webdav/ftp/Data_Collections/Matthews_etal_2016_Global_Plate_Model_GPC.zip"], 
@@ -244,7 +264,8 @@ class DataCollection(object):
 
             "DO_NOT",
             "OLD",
-            "__MACOSX"
+            "__MACOSX",
+            "Clennett_2020_Coastlines", # Clennett et al. 2020
         ]
         return strings
 
@@ -257,7 +278,7 @@ class DataCollection(object):
             "COBfile_1000_0_Toy_introversion",
             "continental",
             "Scotese_2008_PresentDay_ContinentalPolygons.shp", # Scotese 2008
-            "Terrane"
+            # "Terrane",
         ]
         return strings
 
@@ -269,7 +290,8 @@ class DataCollection(object):
             "DO_NOT",
             "OLD",
             "__MACOSX",
-            "Continent-ocean_boundaries"
+            "Continent-ocean_boundaries",
+            "COB",
         ]
         return strings
 
@@ -280,6 +302,7 @@ class DataCollection(object):
 
             "cob",
             "ContinentOceanBoundaries",
+            "COBLineSegments",
         ]
         return strings
 
@@ -290,7 +313,7 @@ class DataCollection(object):
 
             "DO_NOT",
             "OLD",
-            "__MACOSX"
+            "__MACOSX",
         ]
         return strings
 

--- a/gplately/download.py
+++ b/gplately/download.py
@@ -207,17 +207,25 @@ def _str_in_folder(fnames, strings_to_include=None, strings_to_ignore=None):
 
 def _str_in_filename(fnames, strings_to_include=None, strings_to_ignore=None):
     sorted_fnames = []
-    if strings_to_ignore is not None:
-        for f in fnames:
-            f = f.split("/")[-1]
-            check = [s for s in strings_to_ignore if s.lower() in f.lower()]
     if strings_to_include is not None:
-        for s in strings_to_include:
-            for f in fnames:
-                fname = f.split("/")[-1]
-                if s.lower() in fname.lower():
-                    sorted_fnames.append(f)
-    return sorted_fnames
+        for f in fnames:
+            f_splitted = f.split("/")[-1]
+            check = [s for s in strings_to_include if s.lower() in f_splitted.lower()]
+            if check:
+                sorted_fnames.append(f)
+    else:
+        sorted_fnames = fnames
+    
+    if strings_to_ignore is not None:
+        more_sorted = []
+        for f in sorted_fnames:
+            f_splitted = f.split("/")[-1]
+            check = [s for s in strings_to_ignore if s.lower() in f_splitted.lower()]
+            if not check:
+                more_sorted.append(f)
+        return(more_sorted)
+    else:
+        return(sorted_fnames)
 
 
 def _check_gpml_or_shp(fnames):
@@ -405,13 +413,14 @@ class DataServer(object):
         doi: 10.1029/2020GC009244
 
 
-    - __Mather et al. 2021__ : 
+    - __Clennett et al. 2020__ : 
 
-        file_collection = `Mather2021`
+        file_collection = `Clennett2020`
         
         Information
         -----------
-        * Downloadable files: `rotation_model`, `topology_features`, and `coastlines`
+        * Downloadable files: `rotation_model`, `topology_features`, `static_polygons`, `coastlines`
+        and `continents`
         * Maximum reconstruction time: 170 Ma
 
         Citations
@@ -669,18 +678,23 @@ class DataServer(object):
                     fnames = _collection_sorter(
                         download_from_web(url[0]), self.file_collection
                     )
-                    rotation_filenames = _str_in_folder(
-                        _collect_file_extension(fnames, [".rot"]),
+                    rotation_filenames = _collect_file_extension(
+                        _str_in_folder(
+                            _str_in_filename(fnames,
+                                strings_to_ignore=DataCollection.rotation_strings_to_ignore(self)
+                            ),
                         strings_to_ignore=DataCollection.rotation_strings_to_ignore(self)
+                        ),
+                        [".rot"]
                     )
-
                     #print(rotation_filenames)
                     rotation_model = _pygplates.RotationModel(rotation_filenames)
 
                     topology_filenames = _collect_file_extension(
                         _str_in_folder(
                             _str_in_filename(fnames, 
-                                strings_to_include=DataCollection.dynamic_polygon_strings_to_include(self)
+                                strings_to_include=DataCollection.dynamic_polygon_strings_to_include(self),
+                                strings_to_ignore=DataCollection.dynamic_polygon_strings_to_ignore(self)
                             ), 
                             strings_to_ignore=DataCollection.dynamic_polygon_strings_to_ignore(self)
                         ),
@@ -693,14 +707,16 @@ class DataServer(object):
                     static_polygon_filenames = _check_gpml_or_shp(
                         _str_in_folder(
                             _str_in_filename(fnames, 
-                                strings_to_include=DataCollection.static_polygon_strings_to_include(self)
+                                strings_to_include=DataCollection.static_polygon_strings_to_include(self),
+                                strings_to_ignore=DataCollection.static_polygon_strings_to_ignore(self)
                             ),
                             strings_to_ignore=DataCollection.static_polygon_strings_to_ignore(self)
                         )
                     )
+                    #print(static_polygon_filenames)
                     for stat in static_polygon_filenames:
                         static_polygons.add(_pygplates.FeatureCollection(stat))
-                    #print(static_polygons)
+
                 else:
                     for file in url[0]:
                         rotation_filenames.append(
@@ -824,7 +840,8 @@ class DataServer(object):
                             _str_in_folder(
                                 _str_in_filename(
                                     fnames,
-                                    strings_to_include=DataCollection.coastline_strings_to_include(self)
+                                    strings_to_include=DataCollection.coastline_strings_to_include(self),
+                                    strings_to_ignore=DataCollection.coastline_strings_to_ignore(self)
                                 ), 
                                 strings_to_ignore=DataCollection.coastline_strings_to_ignore(self)
                             )
@@ -833,7 +850,8 @@ class DataServer(object):
                             _str_in_folder(
                                 _str_in_filename(
                                     fnames, 
-                                    strings_to_include=DataCollection.continent_strings_to_include(self)
+                                    strings_to_include=DataCollection.continent_strings_to_include(self),
+                                    strings_to_ignore=DataCollection.continent_strings_to_ignore(self)
                                 ), 
                                 strings_to_ignore=DataCollection.continent_strings_to_ignore(self)
                             )
@@ -842,7 +860,8 @@ class DataServer(object):
                             _str_in_folder(
                                 _str_in_filename(
                                     fnames,
-                                    strings_to_include=DataCollection.COB_strings_to_include(self)
+                                    strings_to_include=DataCollection.COB_strings_to_include(self),
+                                    strings_to_ignore=DataCollection.COB_strings_to_ignore(self)
                                 ), 
                                 strings_to_ignore=DataCollection.COB_strings_to_ignore(self)
                             )

--- a/gplately/geometry.py
+++ b/gplately/geometry.py
@@ -1,3 +1,60 @@
+"""Tools for converting PyGPlates or GPlately geometries to Shapely geometries for mapping (and vice versa). 
+
+Supported PyGPlates geometries inherit from the following classes:
+
+* [pygplates.GeometryOnSphere](https://www.gplates.org/docs/pygplates/generated/pygplates.geometryonsphere): This 
+class has the following derived GeometryOnSphere classes:
+    * [pygplates.PointOnSphere](https://www.gplates.org/docs/pygplates/generated/pygplates.pointonsphere#pygplates.PointOnSphere)
+    * [pygplates.MultiPointOnSphere](https://www.gplates.org/docs/pygplates/generated/pygplates.multipointonsphere#pygplates.MultiPointOnSphere)
+    * [pygplates.PolylineOnSphere](https://www.gplates.org/docs/pygplates/generated/pygplates.polylineonsphere#pygplates.PolylineOnSphere)
+    * [pygplates.PolygonOnSphere](https://www.gplates.org/docs/pygplates/generated/pygplates.polygononsphere#pygplates.PolygonOnSphere)
+    
+
+* [pygplates.LatLonPoint](https://www.gplates.org/docs/pygplates/generated/pygplates.latlonpoint)
+* [pygplates.ReconstructedFeatureGeometry](https://www.gplates.org/docs/pygplates/generated/pygplates.reconstructedfeaturegeometry)
+* [pygplates.ResolvedTopologicalLine](https://www.gplates.org/docs/pygplates/generated/pygplates.resolvedtopologicalline)
+* [pygplates.ResolvedTopologicalBoundary](https://www.gplates.org/docs/pygplates/generated/pygplates.resolvedtopologicalboundary)
+* [pygplates.ResolvedTopologicalNetwork](https://www.gplates.org/docs/pygplates/generated/pygplates.resolvedtopologicalnetwork)
+
+Note: GPlately geometries derive from the `GeometryOnSphere` and `pygplates.GeometryOnSphere` base classes. 
+
+Supported Shapely geometric objects include:
+
+* __Point__: a single point in 2D space with coordinate tuple (x,y) or 3D space with coordinate tuple (x,y,z).
+* __LineString__: a sequence of points joined together to form a line (a list of point coordinate tuples).
+* __Polygon__: a sequence of points joined together to form the outer ring of a filled area, or a hole (a list of at least
+three point coordinate tuples).
+
+Also supported are collections of geometric objects, such as:
+
+* __MultiPoint__: a list of __Point__ objects (a list of point coordinate tuples).
+* __MultiLineString__: a list of __LineString__ objects (a list containing lists of point coordinate tuples).
+* __MultiPolygon__:  a list of __Polygon__ objects (a list containing lists of point coordinate tuples that define exterior rings and/or holes).
+
+
+__Converting PyGPlates geometries into Shapely geometries__ involves:
+
+* __wrapping geometries at the dateline__: this involves splitting a polygon, MultiPolygon, line segment or MultiLine segment between
+connecting points at the dateline. This is to ensure the geometry's points are joined along the short path rather than 
+the long path horizontally across the 2D map projection display.
+* __ordering geometries counter-clockwise__
+
+Input PyGPlates geometries are converted to the following Shapely geometries:
+
+- `PointOnSphere` or `LatLonPoint`: `Point`
+- `MultiPointOnSphere`: `MultiPoint`
+- `PolylineOnSphere`: `LineString` or `MultiLineString`
+- `PolygonOnSphere`: `Polygon` or `MultiPolygon`
+
+__Converting Shapely geometries into PyGPlates geometries__: 
+Input Shapely geometries are converted to the following PyGPlates geometries:
+
+- `Point`: `PointOnSphere`
+- `MultiPoint`: `MultiPointOnSphere`
+- `LineString`: `PolylineOnSphere`
+- `LinearRing` or `Polygon`: `PolygonOnSphere`
+
+"""
 import numpy as np
 import pygplates
 from shapely.geometry import (

--- a/gplately/io.py
+++ b/gplately/io.py
@@ -1,3 +1,13 @@
+"""Tools to read geometry data from input files and output them as `Shapely` 
+geometries. These geometries can be plotted directly with GPlately's 
+`PlotTopologies` object.
+
+By default, input files are read with `GeoPandas` and output as a 
+`geopandas.GeoSeries` object that contains `Shapely` geometries.
+If `GeoPandas` is not found on the system, input files are read with 
+`Shapely` instead and are still returned as `Shapely` geometries.
+
+"""
 from shapely.geometry import shape
 from shapely.geometry.base import BaseGeometry
 try:

--- a/gplately/parallel.py
+++ b/gplately/parallel.py
@@ -1,15 +1,48 @@
+"""Tools to execute routines efficiently by parallelising 
+them over several threads. This uses multiple processing units.
+"""
 from multiprocessing import Pool, Process, Queue, cpu_count 
 
 
 class Parallel(object):
-
+    """A class that uses multiple processors with `multiprocessing` 
+    to execute routines in parallel over several threads.
+    
+    Parameters
+    -----------
+    nprocs : int, default=1
+        The number of separate executions of a process. By default,
+        a single thread is run. 
+    """
     def __init__(self, nprocs=1):
 
         self.nprocs = nprocs
 
 
     def parallelise_routine(self, function, *args, **kwargs):
+        """Execute a routine over multiple threads on different 
+        processors, ultimately reducing computation time.
 
+        `parallelise_routine` permits one item through the process 
+        queue when an executed item is extracted with get(). 
+
+        Parameters
+        ----------
+        self.nprocs : int, default=1
+            The number of separate executions of a process. By 
+            default, a single thread is run.
+
+        function : method from an instance of an object
+            The process to be executed in parallel. Should be 
+            supplied as module.class.method (if belonging to a class)
+            or module.method. 
+
+        *args : tuple
+            Contains all necessary input parameters for the ‘function’.
+
+        **kwargs : dict
+            Keyword arguments for the ‘function’.
+        """
         if self.nprocs == 1:
             # single thread
             result = function(*args, **kwargs)


### PR DESCRIPTION
Added the Clennett et al. (2020) reconstruction model to `DataServer`, allowing the on-the-fly download of a rotation model, topology features, static polygons, coastlines, continents and continent-ocean boundaries from webDAV. 

Added a new function `get_spreading_rate_grid()` to `DataServer` which for now accesses the Clennett et al. 2020 netCDF spreading rate grids (which have been uploaded to webDAV). 

(Note: The Clennett et al. 2020 features appear correct on a Cartopy map projection. The global extent of spreading rate grids can be ensured if the line `ax.set_global()` is written BEFORE using any `PlotTopologies` functions.)

Added submodule summaries for the pdoc documentation of:
* io.py
* geometry.py
* parallel.py
