### PR TITLE
Motion paths and flowline notebook

### DIFF
--- a/gplately/reconstruction.py
+++ b/gplately/reconstruction.py
@@ -636,6 +636,8 @@ class PlateReconstruction(object):
             An n-dimensional array with columns containing the latitudes of 
             the seed points at each timestep in `time_array`. There are n 
             columns for n seed points. 
+        StepTimes
+        StepRates
             
         Examples
         --------
@@ -645,17 +647,17 @@ class PlateReconstruction(object):
                 current_lons = lon[:,i]
                 current_lats = lat[:,i]
         """
-
         lons = np.atleast_1d(lons)
         lats = np.atleast_1d(lats)
         time_array = np.atleast_1d(time_array)
-        
+
         # ndarrays to fill with reconstructed points and 
         # rates of motion (if requested)
         rlons = np.empty((len(time_array), len(lons)))
         rlats = np.empty((len(time_array), len(lons)))
-        rates = np.empty((len(time_array)-1, len(lons)))
-        
+        StepTimes = np.empty(((len(time_array)-1)*2, len(lons)))
+        StepRates = np.empty(((len(time_array)-1)*2, len(lons)))
+
         seed_points = list(zip(lats,lons))
         for i, lat_lon in enumerate(seed_points):
 
@@ -673,7 +675,7 @@ class PlateReconstruction(object):
             # Create the motion path feature. enforce float and int for C++ signature.
             motion_path_feature = pygplates.Feature.create_motion_path(
                 seed_points_at_digitisation_time, 
-                time_array.tolist(), 
+                time_array, 
                 valid_time=(time_array.max(), time_array.min()),
                 relative_plate=int(anchor_plate_id),
                 reconstruction_plate_id=int(plate_id))
@@ -681,7 +683,6 @@ class PlateReconstruction(object):
             reconstructed_motion_paths = self.reconstruct(
                 motion_path_feature, 
                 to_time=0, 
-                #from_time=0, 
                 reconstruct_type=pygplates.ReconstructType.motion_path,
                 anchor_plate_id=int(anchor_plate_id),
             )
@@ -693,25 +694,50 @@ class PlateReconstruction(object):
 
             rlons[:,i] = lon
             rlats[:,i] = lat
-        
+
+            # Obtain step-plot coordinates for rate of motion
             if return_rate_of_motion is True:
-                distance = []
+                
+                # Get timestep
+                TimeStep = []
+                for j in range(len(time_array) - 1):
+                    diff = time_array[j + 1] - time_array[j]
+                    TimeStep.append(diff)
+
+                # Iterate over each segment in the reconstructed motion path, get the distance travelled by the moving
+                # plate relative to the fixed plate in each time step
+                Dist = []
                 for reconstructed_motion_path in reconstructed_motion_paths:
                     for segment in reconstructed_motion_path.get_motion_path().get_segments():
-                        # multiply arc length of the motion path segment by a latitude-dependent Earth radius
-                        # use latitude of the segment start point
-                        distance.append(
-                            segment.get_arc_length() * _tools.geocentric_radius(segment.get_start_point().to_lat_lon()[0]) / 1e3
-                        )
-                rate = np.asarray(distance)/np.diff(time_array)
-                rates[:,i] = np.flipud(rate)
-        
+                        Dist.append(segment.get_arc_length() * _tools.geocentric_radius(segment.get_start_point().to_lat_lon()[0]) / 1e3)
+
+                # Note that the motion path coordinates come out starting with the oldest time and working forwards
+                # So, to match our 'times' array, we flip the order
+                Dist = np.flipud(Dist)
+
+                # Get rate of motion as distance per Myr
+                Rate = np.asarray(Dist)/TimeStep
+                
+                # Manipulate arrays to get a step plot
+                StepRate = np.zeros(len(Rate)*2)
+                StepRate[::2] = Rate
+                StepRate[1::2] = Rate
+
+                StepTime = np.zeros(len(Rate)*2)
+                StepTime[::2] = time_array[:-1]
+                StepTime[1::2] = time_array[1:]
+                
+                # Append the nth point's step time and step rate coordinates to the ndarray
+                StepTimes[:,i] = StepTime
+                StepRates[:,i] = StepRate
+
         if return_rate_of_motion is True:
-            return np.squeeze(rlons), np.squeeze(rlats), np.squeeze(rates)
+            return np.squeeze(rlons), np.squeeze(rlats), np.squeeze(StepTimes), np.squeeze(StepRates)
         else:
             return np.squeeze(rlons), np.squeeze(rlats)
 
-    def create_flowline(self, lons, lats, time_array, left_plate_ID, right_plate_ID):
+
+    def create_flowline(self, lons, lats, time_array, left_plate_ID, right_plate_ID, return_rate_of_motion=False):
         """ Create a path of points to track plate motion away from 
         spreading ridges over time using half-stage rotations.
 
@@ -729,6 +755,9 @@ class PlateReconstruction(object):
         right_plate_ID : int
             The plate ID of the polygon to the right of the spreading
             ridge.
+        return_rate_of_motion : bool, default False
+            Choose whether to return a step time and step rate array
+            for a step plot of motion. 
 
         Returns
         -------
@@ -794,6 +823,9 @@ class PlateReconstruction(object):
         left_lat  = np.empty((len(time_array), len(lons)))
         right_lon = np.empty((len(time_array), len(lons)))
         right_lat = np.empty((len(time_array), len(lons)))
+        StepTimes = np.empty(((len(time_array)-1)*2, len(lons)))
+        StepRates = np.empty(((len(time_array)-1)*2, len(lons)))
+
 
         # Iterate over the reconstructed flowlines. Each seed point results in a 'left' and 'right' flowline 
         for i, reconstructed_flowline in enumerate(reconstructed_flowlines):
@@ -808,7 +840,35 @@ class PlateReconstruction(object):
             right_lon[:,i] = right_latlon[:,1]
             right_lat[:,i] = right_latlon[:,0]
 
-        return left_lon[start:], left_lat[start:], right_lon[start:], right_lat[start:]
+        if return_rate_of_motion:
+            for i, reconstructed_motion_path in enumerate(reconstructed_flowlines):
+                distance = []
+                for segment in reconstructed_motion_path.get_left_flowline().get_segments():
+                    distance.append(segment.get_arc_length() * _tools.geocentric_radius(segment.get_start_point().to_lat_lon()[0]) / 1e3)
+                    
+                # Get rate of motion as distance per Myr
+                # Need to multiply rate by 2, since flowlines give us half-spreading rate
+                time_step = time_array[1]-time_array[0]
+                Rate = (np.asarray(distance)/time_step) * 2 # since we created the flowline at X increment
+
+                # Manipulate arrays to get a step plot
+                StepRate = np.zeros(len(Rate)*2)
+                StepRate[::2] = Rate
+                StepRate[1::2] = Rate
+
+                StepTime = np.zeros(len(Rate)*2)
+                StepTime[::2] = time_array[:-1]
+                StepTime[1::2] = time_array[1:]
+
+                # Append the nth point's step time and step rate coordinates to the ndarray
+                StepTimes[:,i] = StepTime
+                StepRates[:,i] = StepRate
+
+            return left_lon[start:], left_lat[start:], right_lon[start:], right_lat[start:], StepTimes, StepRates
+
+        else:
+            return left_lon[start:], left_lat[start:], right_lon[start:], right_lat[start:]
+
 
 
 class Points(object):
@@ -1095,15 +1155,19 @@ class Points(object):
         # rates of motion (if requested)
         rlons = np.empty((len(time_array),   len(self.lons)))
         rlats = np.empty((len(time_array),   len(self.lons)))
-        rates = np.empty((len(time_array)-1, len(self.lons)))
+        StepTimes = np.empty(((len(time_array)-1)*2, len(self.lons)))
+        StepRates = np.empty(((len(time_array)-1)*2, len(self.lons)))
 
-        feature_collection = pygplates.FeaturesFunctionArgument(self.FeatureCollection).get_features()
-
-        for i, feature in enumerate(feature_collection):
+        seed_points = list(zip(self.lats, self.lons))
+        for i, lat_lon in enumerate(seed_points):
+            
+            seed_points_at_digitisation_time = pygplates.PointOnSphere(
+                pygplates.LatLonPoint(float(lat_lon[0]), float(lat_lon[1]))
+            )
 
             # Create the motion path feature
             motion_path_feature = pygplates.Feature.create_motion_path(
-                feature.get_geometry(), 
+                seed_points_at_digitisation_time, 
                 time_array.tolist(),
                 valid_time=(time_array.max(), time_array.min()),
                 #relative_plate=int(self.plate_id[i]),
@@ -1125,26 +1189,50 @@ class Points(object):
 
             rlons[:,i] = lon
             rlats[:,i] = lat
-        
+
+            # Obtain step-plot coordinates for rate of motion
             if return_rate_of_motion is True:
-                distance = []
+                
+                # Get timestep
+                TimeStep = []
+                for j in range(len(time_array) - 1):
+                    diff = time_array[j + 1] - time_array[j]
+                    TimeStep.append(diff)
+
+                # Iterate over each segment in the reconstructed motion path, get the distance travelled by the moving
+                # plate relative to the fixed plate in each time step
+                Dist = []
                 for reconstructed_motion_path in reconstructed_motion_paths:
                     for segment in reconstructed_motion_path.get_motion_path().get_segments():
-                        # multiply arc length of the motion path segment by a latitude-dependent Earth radius
-                        # use latitude of the segment start point
-                        distance.append(
-                            segment.get_arc_length() * _tools.geocentric_radius(segment.get_start_point().to_lat_lon()[0]) / 1e3
-                        )
-                rate = np.asarray(distance)/np.diff(time_array)
-                rates[:,i] = np.flipud(rate)
+                        Dist.append(segment.get_arc_length() * _tools.geocentric_radius(segment.get_start_point().to_lat_lon()[0]) / 1e3)
+
+                # Note that the motion path coordinates come out starting with the oldest time and working forwards
+                # So, to match our 'times' array, we flip the order
+                Dist = np.flipud(Dist)
+
+                # Get rate of motion as distance per Myr
+                Rate = np.asarray(Dist)/TimeStep
+                
+                # Manipulate arrays to get a step plot
+                StepRate = np.zeros(len(Rate)*2)
+                StepRate[::2] = Rate
+                StepRate[1::2] = Rate
+
+                StepTime = np.zeros(len(Rate)*2)
+                StepTime[::2] = time_array[:-1]
+                StepTime[1::2] = time_array[1:]
+                
+                # Append the nth point's step time and step rate coordinates to the ndarray
+                StepTimes[:,i] = StepTime
+                StepRates[:,i] = StepRate
         
         if return_rate_of_motion is True:
-            return np.squeeze(rlons), np.squeeze(rlats), np.squeeze(rates)
+            return np.squeeze(rlons), np.squeeze(rlats), np.squeeze(StepTimes), np.squeeze(StepRates)
         else:
             return np.squeeze(rlons), np.squeeze(rlats)
 
 
-    def flowline(self, time_array, left_plate_ID, right_plate_ID):
+    def flowline(self, time_array, left_plate_ID, right_plate_ID, return_rate_of_motion=False):
         """ Create a path of points to track plate motion away from 
         spreading ridges over time using half-stage rotations.
         
@@ -1162,6 +1250,9 @@ class Points(object):
         right_plate_ID : int
             The plate ID of the polygon to the right of the spreading
             ridge.
+        return_rate_of_motion : bool, default False
+            Choose whether to return a step time and step rate array for
+            a step-plot of flowline motion.
             
         Returns
         -------
@@ -1194,7 +1285,7 @@ class Points(object):
                 right_flowline_latitudes = right_lat[:,i]
         """
         model = self.PlateReconstruction_object
-        return model.create_flowline(self.lons, self.lats, time_array, left_plate_ID, right_plate_ID)
+        return model.create_flowline(self.lons, self.lats, time_array, left_plate_ID, right_plate_ID, return_rate_of_motion)
 
 
     def save(self, filename):

--- a/gplately/tools.py
+++ b/gplately/tools.py
@@ -2,6 +2,7 @@
 """
 import numpy as np
 import pygplates
+import pandas as pd
 
 EARTH_RADIUS = pygplates.Earth.mean_radius_in_kms
 
@@ -395,3 +396,34 @@ def plate_partitioner_for_point(lat_lon_tuple, topology_features, rotation_model
     )
     plate_id_at_present_day = partitioning_plate.get_feature().get_reconstruction_plate_id()
     return(plate_id_at_present_day)
+
+
+def read_rotation_file_pandas(rotation_file_paths):
+    """ Written by Nicky Williams. Extract data from one rotation file, and write 
+    it to a pandas dataframe.
+    """
+    rotation_file = pd.read_csv(
+        rotation_file_paths, 
+        names = ['reconstruction_plate_id', 'age', 'lat', 'lon', 'angle', 'anchor_plate_id', 'comment'], 
+        delim_whitespace=True, 
+        comment='!'
+    )
+    with open(rotation_file_paths, 'r') as f:
+        lines = f.readlines()
+        output = []
+
+        comment = '!'
+        for line in lines:
+            head, sep, tail = line.partition(comment)
+            tail = tail.strip('\n')
+            output.append(tail)
+    
+    rotation_file['comment'] = output
+    
+    return rotation_file
+
+
+def correct_longitudes_for_dateline(lons):
+    lons[lons < 0] += 360 # correct for dateline
+    return lons
+


### PR DESCRIPTION
- Add some functions on gplately.tools to read in .rot files and turn them into pandas data frames. This is to access correct reconstruction times for supported rotation pairs.
- On Notebook 9, rates of motion plots are now step plots, 2-901 rotation uses the Wessel and Kroenke (2008) time array, and the mid-Atlantic flowline plot now has a step-rate plot. Motion path/flowline colours have been changed to easily identify their corresponding rate step plot. 