### PR TITLE
Check before converting to RotationModel

### DIFF
--- a/gplately/reconstruction.py
+++ b/gplately/reconstruction.py
@@ -42,7 +42,8 @@ class PlateReconstruction(object):
         else:
             self.name = None
 
-        rotation_model = pygplates.RotationModel(rotation_model)
+        if not isinstance(rotation_model, pygplates.RotationModel):
+            rotation_model = pygplates.RotationModel(rotation_model)
 
         default_topology_features = pygplates.FeatureCollection()
         for topology in topology_features:
@@ -1689,7 +1690,11 @@ class ReconstructByTopologies(object):
         """
         
         # Turn rotation data into a RotationModel (if not already).
-        self.rotation_model = pygplates.RotationModel(rotation_features_or_model)
+        if not isinstance(rotation_features_or_model, pygplates.RotationModel):
+            rotation_model = pygplates.RotationModel(rotation_features_or_model)
+        else:
+            rotation_model = rotation_features_or_model
+        self.rotation_model = rotation_model
         
         # Turn topology data into a list of features (if not already).
         self.topology_features = pygplates.FeaturesFunctionArgument(topology_features).get_features()

--- a/gplately/tools.py
+++ b/gplately/tools.py
@@ -385,9 +385,11 @@ def plate_partitioner_for_point(lat_lon_tuple, topology_features, rotation_model
     """ Determine the present-day plate ID of a (lat, lon) coordinate pair if 
     it is not specified.
     """
+    if not isinstance(rotation_model, pygplates.RotationModel):
+        rotation_model = pygplates.RotationModel(rotation_model)
     plate_partitioner = pygplates.PlatePartitioner(
         pygplates.FeatureCollection(topology_features), 
-        pygplates.RotationModel(rotation_model), 
+        rotation_model,
         reconstruction_time=float(0)
     )
     partitioning_plate = plate_partitioner.partition_point(


### PR DESCRIPTION
Where appropriate, check that an object is not already a `pygplates.RotationModel` before trying to convert it, as the appropriate `__init__` signature was not present in earlier versions of pygplates.