### PR TITLE
Pickle GPlately objects for parallel-safe multiprocessing

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "gplately" %}
+{% set version = "0.2.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/gplately-{{ version }}.tar.gz
+  sha256: 392ce7ee5d22e7aa996716f2f9ba6c2bb7737a04b176267fb9c5e303b395e54c
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy >=1.16.0
+    - scipy >=1.0.0
+    - shapely
+    - matplotlib-base
+    - cartopy
+    - platetectonictools
+    - pooch
+    - tqdm
+    - netcdf4
+    - rasterio
+    - geopandas
+
+test:
+  imports:
+    - gplately
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/GPlates/gplately
+  summary: Object-orientated Python interface to pyGPlates for plate tectonic reconstructions
+  license: ''
+  license_file: PLEASE_ADD_LICENSE_FILE
+
+extra:
+  recipe-maintainers:
+    - bwhmather

--- a/gplately/__init__.py
+++ b/gplately/__init__.py
@@ -6,7 +6,8 @@ from . import (
     grids,
     io,
     plot,
-    oceans
+    oceans,
+    pygplates
 )
 
 from .data import DataCollection

--- a/gplately/download.py
+++ b/gplately/download.py
@@ -15,6 +15,8 @@ from pooch import HTTPDownloader as _HTTPDownloader
 from pooch import Unzip as _Unzip
 from pooch import Decompress as _Decompress
 from matplotlib import image as _image
+from .pygplates import RotationModel as _RotationModel
+from .pygplates import FeatureCollection as _FeatureCollection
 from gplately.data import DataCollection
 import gplately as _gplately
 import pygplates as _pygplates
@@ -796,8 +798,8 @@ class DataServer(object):
         rotation_filenames = []
         rotation_model = []
         topology_filenames = []
-        topology_features = _pygplates.FeatureCollection()
-        static_polygons= _pygplates.FeatureCollection()
+        topology_features = _FeatureCollection()
+        static_polygons= _FeatureCollection()
         static_polygon_filenames = []
 
         # Locate all plate reconstruction files from GPlately's DataCollection
@@ -824,7 +826,7 @@ class DataServer(object):
                         [".rot"]
                     )
                     #print(rotation_filenames)
-                    rotation_model = _pygplates.RotationModel(rotation_filenames)
+                    rotation_model = _RotationModel(rotation_filenames)
 
                     topology_filenames = _collect_file_extension(
                         _str_in_folder(
@@ -838,7 +840,7 @@ class DataServer(object):
                     )
                     #print(topology_filenames)
                     for file in topology_filenames:
-                        topology_features.add(_pygplates.FeatureCollection(file))
+                        topology_features.add(_FeatureCollection(file))
 
                     static_polygon_filenames = _check_gpml_or_shp(
                         _str_in_folder(
@@ -851,25 +853,17 @@ class DataServer(object):
                     )
                     #print(static_polygon_filenames)
                     for stat in static_polygon_filenames:
-                        static_polygons.add(_pygplates.FeatureCollection(stat))
+                        static_polygons.add(_FeatureCollection(stat))
 
                 else:
                     for file in url[0]:
-                        rotation_filenames.append(
-                            _collect_file_extension(
-                                download_from_web(file, verbose), [".rot"])
-                        )
-                        rotation_model = _pygplates.RotationModel(rotation_filenames)
+                        rotation_filenames.append(_collect_file_extension(download_from_web(file, verbose), [".rot"]))
+                        rotation_model = _RotationModel(rotation_filenames)
 
                     for file in url[1]:
-                        topology_filenames.append(
-                            _collect_file_extension(
-                                download_from_web(file, verbose), [".gpml"])
-                        )
+                        topology_filenames.append(_collect_file_extension(download_from_web(file, verbose), [".gpml"]))
                         for file in topology_filenames:
-                            topology_features.add(
-                                _pygplates.FeatureCollection(file)
-                            )
+                            topology_features.add(_FeatureCollection(file))
 
                     for file in url[2]:
                         static_polygon_filenames.append(
@@ -883,7 +877,7 @@ class DataServer(object):
                             )   
                         )
                         for stat in static_polygon_filenames:
-                            static_polygons.add(_pygplates.FeatureCollection(stat))
+                            static_polygons.add(_FeatureCollection(stat))
                 break
 
         if found_collection is False:
@@ -1052,27 +1046,27 @@ class DataServer(object):
             coastlines_featurecollection = []
         else:
             #print(coastlines)
-            coastlines_featurecollection = _pygplates.FeatureCollection()
+            coastlines_featurecollection = _FeatureCollection()
             for coastline in coastlines:
-                coastlines_featurecollection.add(_pygplates.FeatureCollection(coastline))
+                coastlines_featurecollection.add(_FeatureCollection(coastline))
         
         if not continents:
             print("No continents in {}.".format(self.file_collection))
             continents_featurecollection = []
         else:
             #print(continents)
-            continents_featurecollection = _pygplates.FeatureCollection()
+            continents_featurecollection = _FeatureCollection()
             for continent in continents:
-                continents_featurecollection.add(_pygplates.FeatureCollection(continent))
+                continents_featurecollection.add(_FeatureCollection(continent))
         
         if not COBs:
             print("No continent-ocean boundaries in {}.".format(self.file_collection))
             COBs_featurecollection = []
         else:
             #print(COBs)
-            COBs_featurecollection = _pygplates.FeatureCollection()
+            COBs_featurecollection = _FeatureCollection()
             for COB in COBs:
-                COBs_featurecollection.add(_pygplates.FeatureCollection(COB))
+                COBs_featurecollection.add(_FeatureCollection(COB))
         
         geometries = coastlines_featurecollection, continents_featurecollection, COBs_featurecollection
         return geometries
@@ -1443,13 +1437,13 @@ class DataServer(object):
         if found_collection is False:
             raise ValueError("{} are not in GPlately's DataServer.".format(feature_data_id_string))
 
-        feat_data = _pygplates.FeatureCollection()
+        feat_data = _FeatureCollection()
         if len(feature_data_filenames) == 1:
-                feat_data.add(_pygplates.FeatureCollection(feature_data_filenames[0]))
+                feat_data.add(_FeatureCollection(feature_data_filenames[0]))
                 return feat_data
         else:    
             feat_data=[]
             for file in feature_data_filenames:
-                feat_data.append(_pygplates.FeatureCollection(file))
+                feat_data.append(_FeatureCollection(file))
             return feat_data
     

--- a/gplately/gpml.py
+++ b/gplately/gpml.py
@@ -12,6 +12,8 @@ The following functions are defined here:
 import os
 
 import pygplates
+from .pygplates import FeatureCollection as _FeatureCollection
+from .pygplates import _is_string
 
 __all__ = [
     "create_feature_dict",
@@ -252,3 +254,21 @@ def _parse_features_function_arguments(features):
         else:
             raise e
     return features
+
+def _load_FeatureCollection(geometry):
+    if isinstance(geometry, _FeatureCollection):
+        return geometry
+    elif isinstance(geometry, pygplates.FeatureCollection):
+        geometry.filenames = []
+        return geometry
+    elif _is_string(geometry) and type(geometry) is list:
+        fc = _FeatureCollection()
+        for geom in geometry:
+            fc.add( _FeatureCollection(geom) )
+        return fc
+    elif _is_string(geometry):
+        return _FeatureCollection(geometry)
+    elif geometry is None:
+        return None
+    else:
+        raise ValueError("geometry is an invalid type", type(geometry))

--- a/gplately/plot.py
+++ b/gplately/plot.py
@@ -938,6 +938,8 @@ def _check_object_type(geometry):
         return fc
     elif _is_string(geometry):
         return _FeatureCollection(geometry)
+    elif geometry is None:
+        return None
     else:
         raise ValueError("geometry is an invalid type", type(geometry))
 
@@ -1104,6 +1106,10 @@ class PlotTopologies(object):
         self._continents = _check_object_type(continents)
         self._COBs = _check_object_type(COBs)
 
+        self.coastlines = None
+        self.continents = None
+        self.COBs = None
+
         self._anchor_plate_id = self._check_anchor_plate_id(anchor_plate_id)
 
         # store topologies for easy access
@@ -1115,9 +1121,12 @@ class PlotTopologies(object):
         filenames = self.PlateReconstruction_object.__getstate__()
 
         # add important variables from Points object
-        filenames["coastlines"] = self._coastlines.filenames
-        filenames["continents"] = self._continents.filenames
-        filenames["COBs"] = self._COBs.filenames
+        if self._coastlines:
+            filenames["coastlines"] = self._coastlines.filenames
+        if self._continents:
+            filenames["continents"] = self._continents.filenames
+        if self._COBs:
+            filenames["COBs"] = self._COBs.filenames
         filenames['time'] = self.time
         filenames['plate_id'] = self._anchor_plate_id
 
@@ -1137,19 +1146,28 @@ class PlotTopologies(object):
 
         self.PlateReconstruction_object = _PlateReconstruction(state['rotation_model'], state['topology_features'], state['static_polygons'])
 
+        self._coastlines = None
+        self._continents = None
+        self._COBs = None
+        self.coastlines = None
+        self.continents = None
+        self.COBs = None
+
         # reinstate unpicklable items
+        if 'coastlines' in state:
+            self._coastlines = _FeatureCollection()
+            for feature in state['coastlines']:
+                self._coastlines.add( _FeatureCollection(feature) )
 
-        self._coastlines = _FeatureCollection()
-        for feature in state['coastlines']:
-            self._coastlines.add( _FeatureCollection(feature) )
+        if 'continents' in state:
+            self._continents = _FeatureCollection()
+            for feature in state['continents']:
+                self._continents.add( _FeatureCollection(feature) )
 
-        self._continents = _FeatureCollection()
-        for feature in state['continents']:
-            self._continents.add( _FeatureCollection(feature) )
-
-        self._COBs = _FeatureCollection()
-        for feature in state['COBs']:
-            self._COBs.add( _FeatureCollection(feature) )
+        if 'COBs' in state:
+            self._COBs = _FeatureCollection()
+            for feature in state['COBs']:
+                self._COBs.add( _FeatureCollection(feature) )
 
 
         self._anchor_plate_id = state["plate_id"]

--- a/gplately/plot.py
+++ b/gplately/plot.py
@@ -1097,17 +1097,12 @@ class PlotTopologies(object):
         self.PlateReconstruction_object = PlateReconstruction_object
         self.base_projection = ccrs.PlateCarree()
 
-        # these change when time is set to ReconstructedFeatureGeometry
+        # store these for when time is updated
         # make sure these are initialised as FeatureCollection objects
 
-        self.coastlines = _check_object_type(coastlines)
-        self.continents = _check_object_type(continents)
-        self.COBs = _check_object_type(COBs)
-
-        # store filenames for pickling
-        self.coastline_filenames = self.coastlines.filenames
-        self.continent_filenames = self.continents.filenames
-        self.COB_filenames = self.COBs.filenames
+        self._coastlines = _check_object_type(coastlines)
+        self._continents = _check_object_type(continents)
+        self._COBs = _check_object_type(COBs)
 
         self._anchor_plate_id = self._check_anchor_plate_id(anchor_plate_id)
 
@@ -1120,17 +1115,21 @@ class PlotTopologies(object):
         filenames = self.PlateReconstruction_object.__getstate__()
 
         # add important variables from Points object
-        filenames["coastlines"] = self.coastline_filenames
-        filenames["continents"] = self.continent_filenames
-        filenames["COBs"] = self.COB_filenames
+        filenames["coastlines"] = self._coastlines.filenames
+        filenames["continents"] = self._continents.filenames
+        filenames["COBs"] = self._COBs.filenames
         filenames['time'] = self.time
         filenames['plate_id'] = self._anchor_plate_id
 
         del self.coastlines, self.continents, self.COBs
+        del self._coastlines, self._continents, self._COBs
 
         self.coastlines = None
         self.continents = None
         self.COBs = None
+        self._coastlines = None
+        self._continents = None
+        self._COBs = None
 
         return filenames
 
@@ -1140,23 +1139,18 @@ class PlotTopologies(object):
 
         # reinstate unpicklable items
 
-        self.coastlines = _FeatureCollection()
+        self._coastlines = _FeatureCollection()
         for feature in state['coastlines']:
-            self.coastlines.add( _FeatureCollection(feature) )
+            self._coastlines.add( _FeatureCollection(feature) )
 
-        self.continents = _FeatureCollection()
+        self._continents = _FeatureCollection()
         for feature in state['continents']:
-            self.continents.add( _FeatureCollection(feature) )
+            self._continents.add( _FeatureCollection(feature) )
 
-        self.COBs = _FeatureCollection()
+        self._COBs = _FeatureCollection()
         for feature in state['COBs']:
-            self.COBs.add( _FeatureCollection(feature) )
+            self._COBs.add( _FeatureCollection(feature) )
 
-
-        # store filenames for pickling
-        self.coastline_filenames = self.coastlines.filenames
-        self.continent_filenames = self.continents.filenames
-        self.COB_filenames = self.COBs.filenames
 
         self._anchor_plate_id = state["plate_id"]
         self.time = state['time']
@@ -1289,17 +1283,17 @@ class PlotTopologies(object):
                 self.unclassified_features.append(topol)
 
         # reconstruct other important polygons and lines
-        if self.coastlines:
+        if self._coastlines:
             self.coastlines = self.PlateReconstruction_object.reconstruct(
-                self.coastlines, self.time, from_time=0, anchor_plate_id=self.anchor_plate_id)
+                self._coastlines, self.time, from_time=0, anchor_plate_id=self.anchor_plate_id)
 
-        if self.continents:
+        if self._continents:
             self.continents = self.PlateReconstruction_object.reconstruct(
-                self.continents, self.time, from_time=0, anchor_plate_id=self.anchor_plate_id)
+                self._continents, self.time, from_time=0, anchor_plate_id=self.anchor_plate_id)
 
-        if self.COBs:
+        if self._COBs:
             self.COBs = self.PlateReconstruction_object.reconstruct(
-                self.COBs, self.time, from_time=0, anchor_plate_id=self.anchor_plate_id)
+                self._COBs, self.time, from_time=0, anchor_plate_id=self.anchor_plate_id)
 
 
     # subduction teeth

--- a/gplately/plot.py
+++ b/gplately/plot.py
@@ -30,7 +30,7 @@ from .io import (
     get_geometries as _get_geometries,
 )
 from .tools import EARTH_RADIUS
-
+from .gpml import _load_FeatureCollection
     
 def add_coastlines(ax, reconstruction_time, **kwargs):
     """Reconstruct coastline features to a `reconstruction_time` and plot them as 
@@ -925,25 +925,6 @@ shapelify_feature_lines = shapelify_features
 shapelify_feature_polygons = shapelify_features
 
 
-def _check_object_type(geometry):
-    if isinstance(geometry, _FeatureCollection):
-        return geometry
-    elif isinstance(geometry, pygplates.FeatureCollection):
-        geometry.filenames = []
-        return geometry
-    elif _is_string(geometry) and type(geometry) is list:
-        fc = _FeatureCollection()
-        for geom in geometry:
-            fc.add( _FeatureCollection(geom) )
-        return fc
-    elif _is_string(geometry):
-        return _FeatureCollection(geometry)
-    elif geometry is None:
-        return None
-    else:
-        raise ValueError("geometry is an invalid type", type(geometry))
-
-
 class PlotTopologies(object):
     """A class with tools to read, reconstruct and plot topology features at specific
     reconstruction times.
@@ -1102,9 +1083,9 @@ class PlotTopologies(object):
         # store these for when time is updated
         # make sure these are initialised as FeatureCollection objects
 
-        self._coastlines = _check_object_type(coastlines)
-        self._continents = _check_object_type(continents)
-        self._COBs = _check_object_type(COBs)
+        self._coastlines = _load_FeatureCollection(coastlines)
+        self._continents = _load_FeatureCollection(continents)
+        self._COBs = _load_FeatureCollection(COBs)
 
         self.coastlines = None
         self.continents = None

--- a/gplately/pygplates.py
+++ b/gplately/pygplates.py
@@ -40,11 +40,11 @@ class RotationModel(_pygplates.RotationModel):
             self.filenames = []
         elif isinstance(rotation_features, RotationModel):
             self.filenames = rotation_features.filenames
+        elif hasattr(rotation_features, "filenames"):
+            self.filenames = rotation_features.filenames
         else:
             print("RotationModel: No filename associated with", type(rotation_features), "in __init__")
             self.filenames = []
-
-        self.filenames = rotation_features
 
 class Feature(_pygplates.Feature):
 
@@ -61,6 +61,8 @@ class Feature(_pygplates.Feature):
             self.filenames = []
         elif isinstance(feature, Feature):
             self.filenames = feature.filenames
+        elif hasattr(feature, "filenames"):
+            self.filenames = feature.filenames
         else:
             print("Feature: No filename associated with", type(feature), "in __init__")
             self.filenames = []
@@ -72,6 +74,8 @@ class Feature(_pygplates.Feature):
             self.filenames.extend(feature.filenames)
         elif _is_string(feature):
             self.filenames.extend(feature)
+        elif hasattr(feature, "filenames"):
+            self.filenames.extend(feature.filenames)
         else:
             print("Feature: No filename associated with", type(feature), "in add")
 
@@ -94,6 +98,8 @@ class FeatureCollection(_pygplates.FeatureCollection):
             self.filenames = []
         elif isinstance(features, FeatureCollection):
             self.filenames = features.filenames
+        elif hasattr(features, "filenames"):
+            self.filenames = features.filenames
         else:
             print("FeatureCollection: No filename associated with", type(features), "in __init__")
             self.filenames = []
@@ -106,6 +112,8 @@ class FeatureCollection(_pygplates.FeatureCollection):
             self.filenames.extend(features.filenames)
         elif _is_string(features):
             self.filenames.extend(features)
+        elif hasattr(features, "filenames"):
+            self.filenames.extend(features.filenames)
         else:
             print("FeatureCollection: No filename associated with", type(features), "in add")
 

--- a/gplately/pygplates.py
+++ b/gplately/pygplates.py
@@ -1,0 +1,82 @@
+"""
+A light wrapping of some pyGPlates classes to keep track of filenames
+
+Each object listed here will have a `self.filenames` attribute.
+"""
+
+def _is_string(value):
+    # convert sets to list
+    if type(value) is set:
+        value = list(value)
+
+    # check for strings inside a list
+    if type(value) is list:
+        bl = []
+        for val in value:
+            bl.append( type(val) is str )
+        return all(bl)
+    
+    # if no list, check if string
+    else:
+        return type(value) is str
+
+
+import pygplates as _pygplates
+
+class RotationModel(_pygplates.RotationModel):
+
+    def __init__(self, rotation_features):
+        super(RotationModel, self).__init__(rotation_features)
+        self.filenames = rotation_features
+
+class Feature(_pygplates.Feature):
+
+    def __init__(self, feature):
+        super(Feature, self).__init__(feature)
+        self.filenames = [feature]
+
+    def add(self, feature):
+        super().add(feature)
+        if isinstance(feature, Feature):
+            self.filenames.extend(feature.filenames)
+        elif _is_string(feature):
+            self.filenames.extend(feature)
+        else:
+            raise ValueError("Unsupported type: ", type(feature))
+
+    def clone(self):
+        feat = super().clone()
+        feat.filenames = self.filenames
+
+class FeatureCollection(_pygplates.FeatureCollection):
+
+    def __init__(self, features=None):
+        super(FeatureCollection, self).__init__(features)
+
+        # update filename list
+        if _is_string(features) and type(features) is list:
+            self.filenames = features
+        elif _is_string(features) and type(features) is str:
+            self.filenames = [features]
+        elif features is None:
+            self.filenames = []
+        elif isinstance(features, FeatureCollection):
+            self.filenames.extend(features.filenames)
+        else:
+            raise ValueError("Unsupported type:", type(features))
+
+    def add(self, features):
+        super().add(features)
+
+        # update filename list
+        if isinstance(features, FeatureCollection):
+            self.filenames.extend(features.filenames)
+        elif _is_string(features):
+            self.filenames.extend(features)
+        else:
+            raise ValueError("Unsupported type: ", type(features))
+
+    def clone(self):
+        fc = super().clone()
+        fc.filenames = self.filenames
+        return fc

--- a/gplately/pygplates.py
+++ b/gplately/pygplates.py
@@ -41,7 +41,7 @@ class RotationModel(_pygplates.RotationModel):
         elif isinstance(rotation_features, RotationModel):
             self.filenames = rotation_features.filenames
         else:
-            print("RotationModel: No filename associated with", type(feature), "in __init__")
+            print("RotationModel: No filename associated with", type(rotation_features), "in __init__")
             self.filenames = []
 
         self.filenames = rotation_features

--- a/gplately/pygplates.py
+++ b/gplately/pygplates.py
@@ -4,6 +4,10 @@ A light wrapping of some pyGPlates classes to keep track of filenames
 Each object listed here will have a `self.filenames` attribute.
 """
 
+import pygplates as _pygplates
+from pygplates import *
+
+
 def _is_string(value):
     # convert sets to list
     if type(value) is set:
@@ -21,19 +25,46 @@ def _is_string(value):
         return type(value) is str
 
 
-import pygplates as _pygplates
-
 class RotationModel(_pygplates.RotationModel):
 
     def __init__(self, rotation_features):
         super(RotationModel, self).__init__(rotation_features)
+        self.filenames = []
+
+        # update filename list
+        if _is_string(rotation_features) and type(rotation_features) is list:
+            self.filenames = rotation_features
+        elif _is_string(rotation_features) and type(rotation_features) is str:
+            self.filenames = [rotation_features]
+        elif rotation_features is None:
+            self.filenames = []
+        elif isinstance(rotation_features, RotationModel):
+            self.filenames = rotation_features.filenames
+        else:
+            print("RotationModel: No filename associated with", type(feature), "in __init__")
+            self.filenames = []
+
         self.filenames = rotation_features
 
 class Feature(_pygplates.Feature):
 
     def __init__(self, feature):
         super(Feature, self).__init__(feature)
-        self.filenames = [feature]
+        self.filenames = []
+
+        # update filename list
+        if _is_string(feature) and type(feature) is list:
+            self.filenames = feature
+        elif _is_string(feature) and type(feature) is str:
+            self.filenames = [feature]
+        elif feature is None:
+            self.filenames = []
+        elif isinstance(feature, Feature):
+            self.filenames = feature.filenames
+        else:
+            print("Feature: No filename associated with", type(feature), "in __init__")
+            self.filenames = []
+
 
     def add(self, feature):
         super().add(feature)
@@ -42,7 +73,7 @@ class Feature(_pygplates.Feature):
         elif _is_string(feature):
             self.filenames.extend(feature)
         else:
-            raise ValueError("Unsupported type: ", type(feature))
+            print("Feature: No filename associated with", type(feature), "in add")
 
     def clone(self):
         feat = super().clone()
@@ -52,6 +83,7 @@ class FeatureCollection(_pygplates.FeatureCollection):
 
     def __init__(self, features=None):
         super(FeatureCollection, self).__init__(features)
+        self.filenames = []
 
         # update filename list
         if _is_string(features) and type(features) is list:
@@ -61,9 +93,10 @@ class FeatureCollection(_pygplates.FeatureCollection):
         elif features is None:
             self.filenames = []
         elif isinstance(features, FeatureCollection):
-            self.filenames.extend(features.filenames)
+            self.filenames = features.filenames
         else:
-            raise ValueError("Unsupported type:", type(features))
+            print("FeatureCollection: No filename associated with", type(features), "in __init__")
+            self.filenames = []
 
     def add(self, features):
         super().add(features)
@@ -74,7 +107,7 @@ class FeatureCollection(_pygplates.FeatureCollection):
         elif _is_string(features):
             self.filenames.extend(features)
         else:
-            raise ValueError("Unsupported type: ", type(features))
+            print("FeatureCollection: No filename associated with", type(features), "in add")
 
     def clone(self):
         fc = super().clone()

--- a/gplately/reconstruction.py
+++ b/gplately/reconstruction.py
@@ -998,7 +998,7 @@ class Points(object):
                 plate_id[i] = feature.get_reconstruction_plate_id()
 
         self.plate_id = plate_id
-        self.FeatureCollection = _FeatureCollection(self.features)
+        self.FeatureCollection = pygplates.FeatureCollection(self.features)
 
 
     def __getstate__(self):

--- a/gplately/reconstruction.py
+++ b/gplately/reconstruction.py
@@ -65,13 +65,13 @@ class PlateReconstruction(object):
                      "topology_features": self.topology_features.filenames,\
                      "static_polygons": self.static_polygons.filenames}
 
-        # remove unpicklable items
-        del self.rotation_model, self.topology_features, self.static_polygons
+        # # remove unpicklable items
+        # del self.rotation_model, self.topology_features, self.static_polygons
         
-        # really make sure they're gone
-        self.rotation_model = None
-        self.topology_features = None
-        self.static_polygons = None
+        # # really make sure they're gone
+        # self.rotation_model = None
+        # self.topology_features = None
+        # self.static_polygons = None
 
         return filenames
 

--- a/gplately/reconstruction.py
+++ b/gplately/reconstruction.py
@@ -9,6 +9,7 @@ import math
 from . import tools as _tools
 from .pygplates import RotationModel as _RotationModel
 from .pygplates import FeatureCollection as _FeatureCollection
+from .gpml import _load_FeatureCollection
 
 
 class PlateReconstruction(object):
@@ -36,34 +37,25 @@ class PlateReconstruction(object):
         features.
     """
     
-    def __init__(self, rotation_model=None, topology_features=None, static_polygons=None):
+    def __init__(self, rotation_model, topology_features=None, static_polygons=None):
 
         if hasattr(rotation_model, "reconstruction_identifier"):
             self.name = rotation_model.reconstruction_identifier
         else:
             self.name = None
 
-        if not isinstance(rotation_model, pygplates.RotationModel) \
-        or not isinstance(rotation_model, _RotationModel):
-            rotation_model = _RotationModel(rotation_model)
-
-        if not isinstance(topology_features, _FeatureCollection) \
-        or not isinstance(topology_features, pygplates.FeatureCollection):        
-            default_topology_features = _FeatureCollection()
-            for topology in topology_features:
-                default_topology_features.add( _FeatureCollection(topology) )
-            topology_features = default_topology_features
-
-        # To-do: should set up setter/getters for these attributes
-        self.rotation_model = rotation_model
-        self.topology_features = topology_features
-        self.static_polygons = static_polygons
+        self.rotation_model = _RotationModel(rotation_model)
+        self.topology_features = _load_FeatureCollection(topology_features)
+        self.static_polygons = _load_FeatureCollection(static_polygons)
 
     def __getstate__(self):
 
-        filenames = {"rotation_model": self.rotation_model.filenames,\
-                     "topology_features": self.topology_features.filenames,\
-                     "static_polygons": self.static_polygons.filenames}
+        filenames = {"rotation_model": self.rotation_model.filenames}
+
+        if self.topology_features:
+            filenames['topology_features'] = self.topology_features.filenames
+        if self.static_polygons:
+            filenames['static_polygons'] = self.static_polygons.filenames
 
         # # remove unpicklable items
         # del self.rotation_model, self.topology_features, self.static_polygons
@@ -80,13 +72,19 @@ class PlateReconstruction(object):
 
         # reinstate unpicklable items
         self.rotation_model = _RotationModel(state['rotation_model'])
-        self.topology_features = _FeatureCollection()
-        for topology in state['topology_features']:
-            self.topology_features.add( _FeatureCollection(topology) )
 
-        self.static_polygons = _FeatureCollection()
-        for polygon in state['static_polygons']:
-            self.static_polygons.add( _FeatureCollection(polygon) )
+        self.topology_features = None
+        self.static_polygons = None
+
+        if 'topology_features' in state:
+            self.topology_features = _FeatureCollection()
+            for topology in state['topology_features']:
+                self.topology_features.add( _FeatureCollection(topology) )
+
+        if 'static_polygons' in state:
+            self.static_polygons = _FeatureCollection()
+            for polygon in state['static_polygons']:
+                self.static_polygons.add( _FeatureCollection(polygon) )
 
 
     def tesselate_subduction_zones(self, time, tessellation_threshold_radians=0.001, ignore_warnings=False, **kwargs):

--- a/test/test_1_reconstructions.py
+++ b/test/test_1_reconstructions.py
@@ -92,3 +92,8 @@ def test_point_velocities(time, model):
     lats = [15]
     point_velocities = model.get_point_velocities(lons, lats, time, delta_time=1.0)
     assert point_velocities.any(), "Could not calculate point data velocities for Muller et al. (2019) at {} Ma.".format(time)
+
+def test_pickle_Points():
+    import pickle
+    model_dump = pickle.dumps(model)
+    model_load = pickle.loads(model_dump)

--- a/test/test_2_points.py
+++ b/test/test_2_points.py
@@ -36,3 +36,9 @@ def test_point_reconstruction(time, gpts):
 def test_plate_velocity(time, gpts):
     plate_vel = gpts.plate_velocity(time, delta_time=1)
     assert plate_vel, "Unable to calculate plate velocities of point data at {} Ma with Muller et al. (2019).".format(time)
+
+
+def test_pickle_Points():
+    import pickle
+    gpts_dump = pickle.dumps(gpts)
+    gpts_load = pickle.loads(gpts_dump)

--- a/test/test_3_plottopologies.py
+++ b/test/test_3_plottopologies.py
@@ -96,3 +96,8 @@ def test_PlotTopologies_trench_L(time, gplot):
 def test_PlotTopologies_trench_R(time, gplot):
     assert gplot.trench_right, "No trench (R) features from Müller et al. (2019) at {} Ma are attributed to <gplately.PlotTopologies>.".format(time)
     assert [trench_r.get_feature_type() == "gpml:SubductionZone" for trench_r in gplot.trench_right], "<gplately.PlotTopologies> trenches (R) are not all of type gpml:SubductionZone in Müller et al. (2019) at {} Ma.".format(time)
+
+def test_pickle_Points():
+    import pickle
+    gplot_dump = pickle.dumps(gplot)
+    gplot_load = pickle.loads(gplot_dump)


### PR DESCRIPTION
Implement `__getstate__` and `__setstate__` methods on `PlateReconstruction` and `PlotTopologies` classes to support pickling and unpicking. This works because the rotation models, topology features, static polygons, etc. are all subclassed so they can be safely deleted from the main object and read back in. This requires us to keep track of filenames, thus we add a `filenames` attribute to `pygplates.FeatureCollection`, `pygplates.Feature`, and `pygplates.RotationModel` classes. It is therefore required that the user access pygplates from within gplately (i.e. `gplately.pygplates`) to be sure the augmented classes are used.