### PR TITLE
Update geometry module and add tests

### DIFF
--- a/gplately/geometry.py
+++ b/gplately/geometry.py
@@ -114,6 +114,11 @@ class GeometryOnSphere(pygplates.GeometryOnSphere):
             explode=explode,
         )
 
+    @classmethod
+    def from_shapely(cls, geom):
+        converted = shapely_to_pygplates(geom)
+        return cls(converted)
+
 
 class PointOnSphere(pygplates.PointOnSphere, GeometryOnSphere):
     """GPlately equivalent of `pygplates.PointOnSphere`, incorporating

--- a/gplately/geometry.py
+++ b/gplately/geometry.py
@@ -319,7 +319,7 @@ def _ensure_ccw(geometry):
 
 
 def shapely_to_pygplates(geometry):
-    """Convert one or more Shapely geometries to PyGPlates format.
+    """Convert one or more Shapely geometries to gplately format.
 
     Parameters
     ----------
@@ -328,32 +328,31 @@ def shapely_to_pygplates(geometry):
 
     Returns
     -------
-    output_geometry : pygplates.GeometryOnSphere or list
-        Converted PyGPlates geometry or geometries.
+    output_geometry : GeometryOnSphere or list
+        Converted gplately geometry or geometries.
 
     Notes
     -----
     If a single input geometry was passed, `output_geometry` will be a
-    subclass of `pygplates.GeometryOnSphere`. Otherwise, `output_geometry`
-    will be a list of `pygplates.GeometryOnSphere`, of the same length as
+    subclass of `GeometryOnSphere`. Otherwise, `output_geometry`
+    will be a list of `GeometryOnSphere`, of the same length as
     the input.
 
     Input geometry types are converted as follows:
         - `Point`: `PointOnSphere`
         - `MultiPoint`: `MultiPointOnSphere`
         - `LineString`: `PolylineOnSphere`
-        - `LinearRing` or `Polygon`:
-            `PolygonOnSphere`
+        - `LinearRing` or `Polygon`: `PolygonOnSphere`
 
     Multi-part input geometry types other than `MultiPoint` will be treated
     as an iterable of their component single-part geometries.
     """
     pygplates_conversion = {
-        _Point: pygplates.PointOnSphere,
-        _MultiPoint: pygplates.MultiPointOnSphere,
-        _LineString: pygplates.PolylineOnSphere,
-        _LinearRing: pygplates.PolygonOnSphere,
-        _Polygon: pygplates.PolygonOnSphere,
+        _Point: PointOnSphere,
+        _MultiPoint: MultiPointOnSphere,
+        _LineString: PolylineOnSphere,
+        _LinearRing: PolygonOnSphere,
+        _Polygon: PolygonOnSphere,
     }
 
     if isinstance(geometry, _BaseMultipartGeometry) and not isinstance(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,10 @@ reconstruction_times = [0, 100]
 gridding_times = [249., 250.]
 pt_lon = np.array([-155.4696, 164.3])
 pt_lat = np.array([19.8202, 53.5])
+test_geometry_n_points = 1000
+test_geometry_origins = ((20, -10), (175, -40))  # (lon, lat)
+test_geometry_radii = (100, 500, 1000, 2000)  # km
+test_geometry_azimuths = (45, -100)  # degrees
 
 
 @pytest.fixture(scope="module")

--- a/test/test_3_plottopologies.py
+++ b/test/test_3_plottopologies.py
@@ -1,5 +1,5 @@
 import pytest
-import gplately
+import matplotlib.pyplot as plt
 import numpy as np
 from conftest import reconstruction_times
 from conftest import gplately_plot_topologies_object as gplot
@@ -96,6 +96,15 @@ def test_PlotTopologies_trench_L(time, gplot):
 def test_PlotTopologies_trench_R(time, gplot):
     assert gplot.trench_right, "No trench (R) features from Müller et al. (2019) at {} Ma are attributed to <gplately.PlotTopologies>.".format(time)
     assert [trench_r.get_feature_type() == "gpml:SubductionZone" for trench_r in gplot.trench_right], "<gplately.PlotTopologies> trenches (R) are not all of type gpml:SubductionZone in Müller et al. (2019) at {} Ma.".format(time)
+
+
+# Subduction teeth
+def test_PlotTopologies_subduction_teeth(gplot):
+    ax = plt.gca()
+    gplot.plot_subduction_teeth(ax=ax)
+    fig = plt.gcf()
+    plt.close(fig)
+
 
 def test_pickle_Points():
     import pickle

--- a/test/test_6_geometry.py
+++ b/test/test_6_geometry.py
@@ -105,7 +105,7 @@ def test_polygon_conversion(origin, radius, n_points=N_POINTS):
     circle = Polygon(zip(lons, lats))
     converted = PolygonOnSphere.from_shapely(circle)
     reconverted = converted.to_shapely(
-        central_meridian=converted.get_centroid().to_lat_lon()[1],
+        central_meridian=converted.get_interior_centroid().to_lat_lon()[1],
     )
     assert np.allclose(
         circle.exterior.coords,
@@ -121,7 +121,7 @@ def test_polygon_splitting(n_points=N_POINTS):
     converted = PolygonOnSphere.from_shapely(circle)
     split = converted.to_shapely(central_meridian=0)
     unsplit = converted.to_shapely(
-        central_meridian=converted.get_centroid().to_lat_lon()[1]
+        central_meridian=converted.get_interior_centroid().to_lat_lon()[1]
     )
 
     assert isinstance(

--- a/test/test_6_geometry.py
+++ b/test/test_6_geometry.py
@@ -1,0 +1,115 @@
+from itertools import product
+
+import numpy as np
+import pytest
+from gplately import EARTH_RADIUS
+from gplately.geometry import *
+from shapely.geometry import (
+    Point,
+    LineString,
+    Polygon,
+)
+
+from conftest import (
+    test_geometry_n_points as N_POINTS,
+    test_geometry_origins as origins,
+    test_geometry_radii as RADII,
+)
+
+
+@pytest.mark.parametrize("origin,radius", product(origins, RADII))
+def test_polygon_conversion(origin, radius, n_points=N_POINTS):
+    lons, lats = _get_circle(origin, radius, n=n_points)
+    circle = Polygon(zip(lons, lats))
+    converted = PolygonOnSphere.from_shapely(circle)
+    reconverted = converted.to_shapely(
+        central_meridian=converted.get_centroid().to_lat_lon()[1],
+    )
+    assert np.allclose(
+        circle.exterior.coords,
+        reconverted.exterior.coords,
+    ), "Polygon coordinates not equal"
+
+
+@pytest.mark.parametrize("origin", origins)
+def test_polygon_areas(origin, radii=RADII, n_points=N_POINTS):
+    areas = [_get_circle_areas(r, origin=origin) for r in radii]
+    geometric_areas, pygplates_areas = zip(*areas)
+    assert np.allclose(
+        geometric_areas,
+        pygplates_areas,
+    ), "Polygon areas not equal"
+
+
+@pytest.mark.parametrize("origin", origins)
+def test_polygon_perimeters(origin, radii=RADII, n_points=N_POINTS):
+    perimeters = [_get_circle_perimeters(r, origin=origin) for r in radii]
+    geometric_perimeters, pygplates_perimeters = zip(*perimeters)
+    assert np.allclose(
+        geometric_perimeters,
+        pygplates_perimeters,
+    ), "Polygon perimeters not equal"
+
+
+def _get_circle_perimeters(radius, origin=(0, 0), n=N_POINTS):
+    lons, lats = _get_circle(origin, radius, n=n)
+    circle = Polygon(zip(lons, lats))
+    converted = PolygonOnSphere.from_shapely(circle)
+
+    pygplates_perimeter = converted.get_arc_length() * EARTH_RADIUS
+    geometric_perimeter = (
+        2 * np.pi
+        * EARTH_RADIUS * np.sin(radius / EARTH_RADIUS)
+    )
+    return geometric_perimeter, pygplates_perimeter
+
+
+def _get_circle_areas(radius, origin=(0, 0), n=N_POINTS):
+    lons, lats = _get_circle(origin, radius, n=n)
+    circle = Polygon(zip(lons, lats))
+    converted = PolygonOnSphere.from_shapely(circle)
+
+    pygplates_area = converted.get_area() * (EARTH_RADIUS ** 2)
+    geometric_area = (
+        2 * np.pi *
+        (EARTH_RADIUS ** 2)
+        * (1 - np.cos(radius / EARTH_RADIUS))
+    )
+    return geometric_area, pygplates_area
+
+
+def _point_from_origin_distance_azimuth(
+    origin,
+    distance,
+    azimuth,
+    radius=EARTH_RADIUS,
+):
+    lon1, lat1 = origin
+    lon1 = np.deg2rad(lon1)
+    lat1 = np.deg2rad(lat1)
+    azimuth = np.deg2rad(azimuth)
+
+    b = distance / radius
+    a = np.arccos(
+        np.cos(b) * np.cos(0.5 * np.pi - lat1)
+        + np.sin(0.5 * np.pi - lat1) * np.sin(b) * np.cos(azimuth)
+    )
+    B = np.arcsin(
+        np.sin(b) * np.sin(azimuth)
+        / np.sin(a)
+    )
+    lat2 = np.rad2deg(0.5 * np.pi - a)
+    lon2 = np.rad2deg(B + lon1)
+
+    return lon2, lat2
+
+
+def _get_circle(origin, radius, earth_radius=EARTH_RADIUS, n=N_POINTS):
+    azimuth = np.linspace(0, 360.0, n, endpoint=False)
+    lons, lats = _point_from_origin_distance_azimuth(
+        origin,
+        radius,
+        azimuth,
+        earth_radius,
+    )
+    return lons, lats

--- a/test/test_6_geometry.py
+++ b/test/test_6_geometry.py
@@ -1,20 +1,102 @@
 from itertools import product
 
 import numpy as np
+import pygplates
 import pytest
 from gplately import EARTH_RADIUS
 from gplately.geometry import *
 from shapely.geometry import (
-    Point,
     LineString,
+    MultiPoint,
+    Point,
     Polygon,
 )
+from shapely.geometry.base import BaseMultipartGeometry
 
 from conftest import (
     test_geometry_n_points as N_POINTS,
     test_geometry_origins as origins,
     test_geometry_radii as RADII,
+    test_geometry_azimuths as azimuths,
 )
+
+
+@pytest.mark.parametrize("lat", (-100, 95))
+def test_invalid_point(lat):
+    p = Point(0, lat)
+    with pytest.raises(pygplates.InvalidLatLonError):
+        PointOnSphere.from_shapely(p)
+
+
+def test_multipoint_conversion(n_points=N_POINTS):
+    n_lats = int(np.sqrt(n_points / 2))
+    point_lons = np.linspace(-179, 179, n_lats * 2)
+    point_lats = np.linspace(-89, 89, n_lats)
+    grid_lons, grid_lats = np.meshgrid(point_lons, point_lats)
+
+    mp_shapely = MultiPoint(
+        np.column_stack(
+            [np.ravel(i) for i in (grid_lons, grid_lats)]
+        )
+    )
+    mp_pgp = MultiPointOnSphere.from_shapely(mp_shapely)
+
+    a1 = np.row_stack([i.coords for i in mp_shapely.geoms])
+    a2 = np.fliplr(mp_pgp.to_lat_lon_array())
+    assert np.allclose(
+        a1,
+        a2,
+    ), "Multi-point coordinates not equal"
+
+
+@pytest.mark.parametrize(
+    "origin,azimuth,distance",
+    product(origins, azimuths, RADII),
+)
+def test_polyline_conversion(origin, azimuth, distance, n_points=N_POINTS):
+    lons, lats = _point_from_origin_distance_azimuth(
+        origin,
+        np.linspace(0, distance, n_points),
+        azimuth,
+    )
+    line = LineString(zip(lons, lats))
+    converted = PolylineOnSphere.from_shapely(line)
+    reconverted = converted.to_shapely(
+        central_meridian=converted.get_centroid().to_lat_lon()[1],
+    )
+
+    # Ensure consistency
+    a1 = np.array(line.coords)
+    inds1 = np.where(a1[:, 0] < -180)
+    a1[inds1, 0] += 360
+    inds2 = np.where(a1[:, 0] > 180)
+    a1[inds2, 0] -= 360
+
+    a2 = np.array(reconverted.coords)
+    inds3 = np.where(a2[:, 0] < -180)
+    a2[inds3, 0] += 360
+    inds4 = np.where(a2[:, 0] > 180)
+    a2[inds4, 0] -= 360
+
+    assert np.allclose(a1, a2), "Polyline coordinates not equal"
+
+
+@pytest.mark.parametrize(
+    "origin,azimuth,distance",
+    product(origins, azimuths, RADII),
+)
+def test_polyline_length(origin, azimuth, distance, n_points=N_POINTS):
+    lons, lats = _point_from_origin_distance_azimuth(
+        origin,
+        np.linspace(0, distance, n_points),
+        azimuth,
+    )
+    line = LineString(zip(lons, lats))
+    converted = PolylineOnSphere.from_shapely(line)
+    assert np.allclose(
+        distance,
+        converted.get_arc_length() * EARTH_RADIUS,
+    ), "Polyline length not consistent"
 
 
 @pytest.mark.parametrize("origin,radius", product(origins, RADII))
@@ -31,9 +113,42 @@ def test_polygon_conversion(origin, radius, n_points=N_POINTS):
     ), "Polygon coordinates not equal"
 
 
+def test_polygon_splitting(n_points=N_POINTS):
+    origin = (-179, 0)
+    radius = 1000
+    lons, lats = _get_circle(origin, radius, n=n_points)
+    circle = Polygon(zip(lons, lats))
+    converted = PolygonOnSphere.from_shapely(circle)
+    split = converted.to_shapely(central_meridian=0)
+    unsplit = converted.to_shapely(
+        central_meridian=converted.get_centroid().to_lat_lon()[1]
+    )
+
+    assert isinstance(
+        split,
+        BaseMultipartGeometry,
+    ), "Polygon splitting failed (incorrect output type: {})".format(type(split))
+    assert isinstance(
+        unsplit,
+        Polygon,
+    ), "Polygon conversion failed (incorrect output type: {})".format(
+        type(unsplit)
+    )
+
+    assert (
+        len(split.geoms) == 2
+    ), "Polygon splitting failed (incorrect number of outputs: {})".format(
+        len(split.geoms)
+    )
+
+    assert (
+        np.allclose(split.area, unsplit.area)
+    ), "Polygon splitting area mismatch"
+
+
 @pytest.mark.parametrize("origin", origins)
 def test_polygon_areas(origin, radii=RADII, n_points=N_POINTS):
-    areas = [_get_circle_areas(r, origin=origin) for r in radii]
+    areas = [_get_circle_areas(r, origin=origin, n=n_points) for r in radii]
     geometric_areas, pygplates_areas = zip(*areas)
     assert np.allclose(
         geometric_areas,
@@ -43,7 +158,7 @@ def test_polygon_areas(origin, radii=RADII, n_points=N_POINTS):
 
 @pytest.mark.parametrize("origin", origins)
 def test_polygon_perimeters(origin, radii=RADII, n_points=N_POINTS):
-    perimeters = [_get_circle_perimeters(r, origin=origin) for r in radii]
+    perimeters = [_get_circle_perimeters(r, origin=origin, n=n_points) for r in radii]
     geometric_perimeters, pygplates_perimeters = zip(*perimeters)
     assert np.allclose(
         geometric_perimeters,


### PR DESCRIPTION
This PR includes a few small updates to `gplately/geometry.py`:
 - Add `GeometryOnSphere.from_shapely` class method
 - Change return type of `shapely_to_pygplates` from `pygplates.GeometryOnSphere` to `gplately.geometry.GeometryOnSphere`

It also contains a few tests for the `geometry` module in `test/test_6_geometry.py`.