### PR TITLE
Allow shapely v2

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,7 +25,7 @@ jobs:
         yes | sudo dpkg -i pygplates_package.deb
     - name: Install gplately
       run: |
-        pip install stripy cartopy==0.19.0.post1
+        pip install stripy
         pip install .
     - name: Test with pytest
       run: |

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -24,7 +24,6 @@ jobs:
         yes | sudo dpkg -i pygplates_package.deb
     - name: Install gplately
       run: |
-        pip install cartopy==0.19.0.post1
         pip install .
     - name : Generate documentation with pdoc3
       run : |

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -35,9 +35,6 @@ jobs:
         sudo apt-get install -yq wget libboost-python-dev libboost-program-options-dev libgdal-dev libglew-dev libglu1-mesa libproj-dev libqt5core5a libqt5gui5 libqt5network5 libqt5opengl5 libqt5svg5 libqt5widgets5 libqt5xml5 libqt5xmlpatterns5 libqwt-qt5-6
         wget https://www.earthbyte.org/webdav/ftp/earthbyte/pygplates/pygplates-py3_rev33_ubuntu-20.04-amd64.deb -O pygplates_package.deb
         yes | sudo dpkg -i pygplates_package.deb
-    - name: Install cartopy
-      run: |
-        pip install cartopy==0.19.0.post1
     - name: Build package
       run: |
         export PYTHONPATH=$PYTHONPATH:/usr/lib/

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
           long_description_content_type='text/markdown',
           install_requires  = ['numpy>=1.16.0',
                                'scipy>=1.0.0',
-                               'shapely<2.0',
+                               'shapely>=2.0',
                                'matplotlib',
                                'cartopy',
                                'PlateTectonicTools',

--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,9 @@ if __name__ == "__main__":
           long_description_content_type='text/markdown',
           install_requires  = ['numpy>=1.16.0',
                                'scipy>=1.0.0',
-                               'shapely>=2.0',
+                               'shapely',
                                'matplotlib',
-                               'cartopy>=0.21.1',  # required for shapely>=2.0
+                               'cartopy',
                                'PlateTectonicTools',
                                'pooch',
                                'tqdm',

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
                                'scipy>=1.0.0',
                                'shapely>=2.0',
                                'matplotlib',
-                               'cartopy',
+                               'cartopy>=0.21.1',  # required for shapely>=2.0
                                'PlateTectonicTools',
                                'pooch',
                                'tqdm',


### PR DESCRIPTION
As of [v0.21.1](https://github.com/SciTools/cartopy/releases/tag/v0.21.1), Cartopy is now compatible with shapely v2.0. If we remove the requirement for `shapely<2` in `setup.py` and modify the GitHub workflows files to avoid specifying `cartopy==0.19.0.post1` (e.g. [here](https://github.com/GPlates/gplately/blob/master/.github/workflows/build_and_test.yml#L28)), the build and test workflow passes without a hitch: https://github.com/GPlates/gplately/actions/runs/4310074487.