### PR TITLE
Replace links with raw user content links

### DIFF
--- a/gplately/__init__.py
+++ b/gplately/__init__.py
@@ -1,6 +1,6 @@
 """
 
-![Intro GIF](https://github.com/GPlates/gplately/blob/master/Notebooks/NotebookFiles/pdoc_Files/docs_muller19_seed_points.gif)
+![Intro GIF](https://raw.githubusercontent.com/GPlates/gplately/master/Notebooks/NotebookFiles/pdoc_Files/docs_muller19_seed_points.gif)
 
 ## Main objects
 GPlately's common objects include:
@@ -35,15 +35,15 @@ Tools in the `Points` object track the motion of a point (or group of points) re
 through geologic time. This motion can be visualised using flowlines or motion paths and quantified with point 
 motion velocities.
 
-![PointsDemo](https://github.com/GPlates/gplately/blob/master/Notebooks/NotebookFiles/pdoc_Files/Hawaii_Emperor_motion_path.png)
+![PointsDemo](https://raw.githubusercontent.com/GPlates/gplately/master/Notebooks/NotebookFiles/pdoc_Files/Hawaii_Emperor_motion_path.png)
 
 ### [Raster](https://gplates.github.io/gplately/grids.html#gplately.grids.Raster)
 The `Raster` object contains tools to work with netCDF4 or MaskedArray gridded data. Grids may be filled, 
 resized, resampled, and reconstructed back and forwards through geologic time. Other array data can also be 
 interpolated onto `Raster` grids.  
 
-![RasterDemo](https://github.com/GPlates/gplately/blob/master/Notebooks/NotebookFiles/pdoc_Files/etopo_reconstruction.png)
-![ResampleDemo](https://github.com/GPlates/gplately/blob/master/Notebooks/NotebookFiles/pdoc_Files/resample.png)
+![RasterDemo](https://raw.githubusercontent.com/GPlates/gplately/master/Notebooks/NotebookFiles/pdoc_Files/etopo_reconstruction.png)
+![ResampleDemo](https://raw.githubusercontent.com/GPlates/gplately/master/Notebooks/NotebookFiles/pdoc_Files/resample.png)
 
 
 ### [PlotTopologies](https://gplates.github.io/gplately/plot.html#gplately.plot.PlotTopologies)
@@ -52,7 +52,7 @@ geologic features of different types listed
 [here](https://gplates.github.io/gplately/plot.html#gplately.plot.PlotTopologies), as well as 
 coastline, continent and continent-ocean boundary geometries reconstructed through time using pyGPlates. 
 
-![PlotTopologiesDemo](https://github.com/GPlates/gplately/blob/master/Notebooks/NotebookFiles/pdoc_Files/plottopologies.png)
+![PlotTopologiesDemo](https://raw.githubusercontent.com/GPlates/gplately/master/Notebooks/NotebookFiles/pdoc_Files/plottopologies.png)
 
 ### [SeafloorGrid](https://gplates.github.io/gplately/oceans.html#gplately.oceans.SeafloorGrid)
 The `SeafloorGrid` object wraps an automatic workflow to grid seafloor ages and seafloor spreading rates
@@ -61,7 +61,7 @@ as encoded by a plate reconstruction model.
 [10-SeafloorGrids.ipynb](../gplately/Notebooks/10-SeafloorGrids.ipynb) is a tutorial notebook that demonstrates
 how to set up and use the `SeafloorGrid` object, and shows a sample set of output grids. 
 
-![SeafloorGridDemo](https://github.com/GPlates/gplately/blob/master/Notebooks/NotebookFiles/pdoc_Files/seafloorgrid.gif)
+![SeafloorGridDemo](https://raw.githubusercontent.com/GPlates/gplately/master/Notebooks/NotebookFiles/pdoc_Files/seafloorgrid.gif)
 
 """
 

--- a/gplately/oceans.py
+++ b/gplately/oceans.py
@@ -33,7 +33,7 @@ icosahedral triangulated mesh. The number of points in this mesh can be
 controlled using a `refinement_levels` integer (the larger this integer,
 the more resolved the continent masks will be). 
 
-![RefinementLevels](https://github.com/GPlates/gplately/blob/master/Notebooks/NotebookFiles/pdoc_Files/seafloorgrid_refinement.png)
+![RefinementLevels](https://raw.githubusercontent.com/GPlates/gplately/master/Notebooks/NotebookFiles/pdoc_Files/seafloorgrid_refinement.png)
 
 These points are spatially partitioned by plate ID so they can be passed
 into a 
@@ -52,7 +52,7 @@ Thus, the spreading rate grid at `max_time` will be uniformly populated with the
 The age grid at `max_time` will look like a series of smooth, linear age gradients clearly partitioned by 
 tectonic plates with unique plate IDs:
 
-![MaxTimeGrids](https://github.com/GPlates/gplately/blob/master/Notebooks/NotebookFiles/pdoc_Files/max_time_grids.png)
+![MaxTimeGrids](https://raw.githubusercontent.com/GPlates/gplately/master/Notebooks/NotebookFiles/pdoc_Files/max_time_grids.png)
 
 [Ridge "line" topologies](https://gplates.github.io/gplately/oceans.html#gplately.oceans.SeafloorGrid.build_all_MOR_seedpoints) 
 are resolved at each reconstruction time step and partitioned
@@ -62,7 +62,7 @@ ascribed a latitude, longitude, spreading rate and age (from plate reconstructio
 model files, as opposed to ages of the initial ocean mesh points), a point index 
 and the general z-value that will be gridded onto it. 
 
-![NewRidgePoints](https://github.com/GPlates/gplately/blob/master/Notebooks/NotebookFiles/pdoc_Files/new_ridge_points.png)
+![NewRidgePoints](https://raw.githubusercontent.com/GPlates/gplately/master/Notebooks/NotebookFiles/pdoc_Files/new_ridge_points.png)
 
 Reconstruction by topologies involves determining which points are active and 
 inactive (collided with a continent or subducted at a trench) for each reconstruction 
@@ -128,7 +128,7 @@ from ptt import separate_ridge_transform_segments
 
 def create_icosahedral_mesh(refinement_levels):
     """ Define a global point mesh with Stripy's
-    [icosahedral triangulated mesh][https://github.com/underworldcode/stripy/blob/294354c00dd72e085a018e69c345d9353c6fafef/stripy/spherical_meshes.py#L27] 
+    [icosahedral triangulated mesh](https://github.com/underworldcode/stripy/blob/294354c00dd72e085a018e69c345d9353c6fafef/stripy/spherical_meshes.py#L27)
     and turn all mesh domains into pyGPlates MultiPointOnSphere types.
 
     This global mesh will be masked with a set of continental or COB terrane


### PR DESCRIPTION
Repo links have been changed to raw user content links - top level documentation and oceans.py documentation should now render properly.