### PR TITLE
Small fix in collision detection

### DIFF
--- a/gplately/reconstruction.py
+++ b/gplately/reconstruction.py
@@ -1846,7 +1846,11 @@ class _DefaultCollision(object):
             distance_threshold_radians = ((threshold_distance_to_boundary_per_my + delta_velocity_magnitude)
                 * reconstruction_time_interval / pygplates.Earth.equatorial_radius_in_kms)
 
-            if pygplates.GeometryOnSphere.distance(prev_point, prev_boundary_geometry, distance_threshold_radians) is not None:
+            distance = pygplates.GeometryOnSphere.distance(
+                prev_point,
+                prev_boundary_geometry,
+            )
+            if distance > distance_threshold_radians:
                 # Detected a collision.
                 return True
         

--- a/gplately/reconstruction.py
+++ b/gplately/reconstruction.py
@@ -1850,7 +1850,7 @@ class _DefaultCollision(object):
                 prev_point,
                 prev_boundary_geometry,
             )
-            if distance > distance_threshold_radians:
+            if distance <= distance_threshold_radians:
                 # Detected a collision.
                 return True
         


### PR DESCRIPTION
Avoid providing the `distance_threshold_radians` argument to `GeometryOnSphere.distance` when it may be greater than pi.

This prevents a potential `pygplates.PreconditionViolationError` when creating seafloor age grids. 