### PR TITLE
Add agegrid CLI

### DIFF
--- a/gplately/__main__.py
+++ b/gplately/__main__.py
@@ -1,7 +1,12 @@
 import argparse
 import os
 import sys
-from typing import List
+from typing import (
+    Iterable,
+    List,
+    Optional,
+    Union,
+)
 
 import pygplates
 
@@ -68,6 +73,79 @@ def filter_feature_collection(args):
     )
 
 
+def create_agegrids(
+    input_filenames: Union[str, Iterable[str]],
+    continents_filenames: Union[str, Iterable[str]],
+    output_dir: str,
+    min_time: float,
+    max_time: float,
+    ridge_time_step: float = 1,
+    n_jobs: int = 1,
+    refinement_levels: int = 5,
+    grid_spacing: float = 0.1,
+    ridge_sampling: float = 0.5,
+    initial_spreadrate: float = 75,
+    file_collection: Optional[str] = None,
+    unmasked: bool = False,
+) -> None:
+    from gplately import (
+        PlateReconstruction,
+        PlotTopologies,
+        SeafloorGrid,
+    )
+
+    features = pygplates.FeaturesFunctionArgument(
+        input_filenames
+    ).get_features()
+    rotations = []
+    topologies = []
+    for i in features:
+        if (
+            i.get_feature_type().to_qualified_string()
+            == "gpml:TotalReconstructionSequence"
+        ):
+            rotations.append(i)
+        else:
+            topologies.append(i)
+    topologies = pygplates.FeatureCollection(topologies)
+    rotations = pygplates.RotationModel(rotations)
+
+    if continents_filenames is None:
+        continents = pygplates.FeatureCollection()
+    else:
+        continents = pygplates.FeatureCollection(
+            pygplates.FeaturesFunctionArgument(
+                continents_filenames
+            ).get_features()
+        )
+
+    reconstruction = PlateReconstruction(
+        rotation_model=rotations,
+        topology_features=topologies,
+    )
+    gplot = PlotTopologies(
+        reconstruction,
+        continents=continents,
+    )
+
+    grid = SeafloorGrid(
+        reconstruction,
+        gplot,
+        min_time=min_time,
+        max_time=max_time,
+        save_directory=output_dir,
+        ridge_time_step=ridge_time_step,
+        refinement_levels=refinement_levels,
+        grid_spacing=grid_spacing,
+        ridge_sampling=ridge_sampling,
+        initial_ocean_mean_spreading_rate=initial_spreadrate,
+        file_collection=file_collection,
+    )
+    grid.reconstruct_by_topologies()
+    for val in ("SEAFLOOR_AGE", "SPREADING_RATE"):
+        grid.lat_lon_z_to_netCDF(val, unmasked=unmasked, nprocs=n_jobs)
+
+
 class ArgParser(argparse.ArgumentParser):
     def error(self, message):
         sys.stderr.write(f"error: {message}\n")
@@ -84,6 +162,12 @@ def main():
     subparser = parser.add_subparsers(dest="command")
     combine_cmd = subparser.add_parser("combine")
     filter_cmd = subparser.add_parser("filter")
+    agegrid_cmd = subparser.add_parser(
+        "agegrid",
+        aliases=("ag",),
+        add_help=True,
+        description="Create age grids for a plate model.",
+    )
 
     # combine command arguments
     combine_cmd.add_argument("combine_first_input_file", type=str)
@@ -115,6 +199,102 @@ def main():
     )
     filter_cmd.add_argument("--exact-match", dest="exact_match", action="store_true")
 
+    # agegrid command arguments
+    agegrid_cmd.add_argument(
+        metavar="INPUT_FILE",
+        nargs="+",
+        help="input reconstruction files",
+        dest="input_filenames",
+    )
+    agegrid_cmd.add_argument(
+        metavar="OUTPUT_DIR",
+        help="output directory",
+        dest="output_dir",
+    )
+    agegrid_cmd.add_argument(
+        "-c",
+        "--continents",
+        metavar="CONTINENTS_FILE",
+        nargs="+",
+        help="input continent files",
+        dest="continents_filenames",
+        default=None,
+    )
+    agegrid_cmd.add_argument(
+        "-r",
+        "--resolution",
+        metavar="RESOLUTION",
+        type=float,
+        help="grid resolution (degrees); default: 0.1",
+        default=0.1,
+        dest="grid_spacing",
+    )
+    agegrid_cmd.add_argument(
+        "--refinement-levels",
+        metavar="LEVELS",
+        type=int,
+        help="mesh refinement levels; default: 5",
+        default=5,
+        dest="refinement_levels",
+    )
+    agegrid_cmd.add_argument(
+        "--ridge-sampling",
+        metavar="RESOLUTION",
+        type=float,
+        help="MOR sampling resolution (degrees); default: 0.5",
+        default=0.5,
+        dest="ridge_sampling",
+    )
+    agegrid_cmd.add_argument(
+        "--initial-spreadrate",
+        metavar="SPREADRATE",
+        type=float,
+        help="initial ocean spreading rate (km/Myr); default: 75",
+        default=75,
+        dest="initial_spreadrate",
+    )
+    agegrid_cmd.add_argument(
+        "-e",
+        "--min-time",
+        metavar="MIN_TIME",
+        type=float,
+        help="minimum time (Ma)",
+        default=0,
+        dest="min_time",
+    )
+    agegrid_cmd.add_argument(
+        "-s",
+        "--max-time",
+        metavar="MAX_TIME",
+        type=float,
+        help="maximum time (Ma)",
+        default=0,
+        dest="max_time",
+    )
+    agegrid_cmd.add_argument(
+        "-j",
+        "--n_jobs",
+        help="number of processes to use; default: 1",
+        metavar="N_JOBS",
+        default=1,
+        dest="n_jobs",
+    )
+    agegrid_cmd.add_argument(
+        "-f",
+        "--file-collection",
+        help="file collection name; default: None",
+        metavar="NAME",
+        default=None,
+        dest="file_collection",
+    )
+    agegrid_cmd.add_argument(
+        "-u",
+        "--include-unmasked",
+        help="create unmasked grids in addition to masked ones",
+        action="store_true",
+        dest="unmasked",
+    )
+
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
@@ -132,8 +312,23 @@ def main():
         )
     elif args.command == "filter":
         filter_feature_collection(args)
+    elif args.command == "agegrid":
+        create_agegrids(
+            input_filenames=args.input_filenames,
+            continents_filenames=args.continents_filenames,
+            output_dir=args.output_dir,
+            min_time=args.min_time,
+            max_time=args.max_time,
+            n_jobs=args.n_jobs,
+            refinement_levels=args.refinement_levels,
+            grid_spacing=args.grid_spacing,
+            ridge_sampling=args.ridge_sampling,
+            initial_spreadrate=args.initial_spreadrate,
+            file_collection=args.file_collection,
+            unmasked=args.unmasked,
+        )
     else:
-        print(f"Unknow command {args.command}!")
+        print(f"Unknown command {args.command}!")
         parser.print_help(sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
The new `gplately agegrid` (or `gplately ag`) command will take a list of input files, a start and end time, and an output directory to create seafloor age and spreading rate grids. For full usage, see below:

```
usage: gplately agegrid [-h] [-c CONTINENTS_FILE [CONTINENTS_FILE ...]] [-r RESOLUTION] [--refinement-levels LEVELS] [--ridge-sampling RESOLUTION]
                        [--initial-spreadrate SPREADRATE] [-e MIN_TIME] [-s MAX_TIME] [-j N_JOBS] [-f NAME] [-u]
                        INPUT_FILE [INPUT_FILE ...] OUTPUT_DIR

Create age grids for a plate model.

positional arguments:
  INPUT_FILE            input reconstruction files
  OUTPUT_DIR            output directory

options:
  -h, --help            show this help message and exit
  -c CONTINENTS_FILE [CONTINENTS_FILE ...], --continents CONTINENTS_FILE [CONTINENTS_FILE ...]
                        input continent files
  -r RESOLUTION, --resolution RESOLUTION
                        grid resolution (degrees); default: 0.1
  --refinement-levels LEVELS
                        mesh refinement levels; default: 5
  --ridge-sampling RESOLUTION
                        MOR sampling resolution (degrees); default: 0.5
  --initial-spreadrate SPREADRATE
                        initial ocean spreading rate (km/Myr); default: 75
  -e MIN_TIME, --min-time MIN_TIME
                        minimum time (Ma); default: 0
  -s MAX_TIME, --max-time MAX_TIME
                        maximum time (Ma); default: 0
  -j N_JOBS, --n_jobs N_JOBS
                        number of processes to use; default: 1
  -f NAME, --file-collection NAME
                        file collection name (optional)
  -u, --include-unmasked
                        create unmasked grids in addition to masked ones
```