### PR TITLE
Correct circular imports for PTT

### DIFF
--- a/gplately/__init__.py
+++ b/gplately/__init__.py
@@ -184,6 +184,7 @@ from . import (
     pygplates,
     read_geometries,
     reconstruction,
+    ptt
 )
 
 from .data import DataCollection
@@ -221,6 +222,7 @@ __all__ = [
     "read_geometries",
     "reconstruction",
     "plate_model_manager",
+    "ptt",
     # Classes
     "DataCollection",
     "DataServer",

--- a/gplately/reconstruction.py
+++ b/gplately/reconstruction.py
@@ -8,8 +8,8 @@ import warnings
 import numpy as np
 import pygplates
 
-from . import ptt
-from . import tools as _tools
+import gplately.ptt as ptt
+import gplately.tools as _tools
 from .gpml import _load_FeatureCollection
 from .pygplates import FeatureCollection as _FeatureCollection
 from .pygplates import RotationModel as _RotationModel

--- a/tests-dir/pytestcases/test_0_imports.py
+++ b/tests-dir/pytestcases/test_0_imports.py
@@ -29,6 +29,7 @@ def test_gplately_modules():
     from gplately import download
     from gplately import tools
     from gplately import grids
+    from gplately import ptt
 
 
 def test_jupyter_available():


### PR DESCRIPTION
Conda was failing because of circular imports.

```
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/gplately_1699874743383/test_tmp/run_test.py", line 2, in <module>
    import gplately
  File "/home/conda/feedstock_root/build_artifacts/gplately_1699874743383/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.11/site-packages/gplately/__init__.py", line 176, in <module>
    from . import (
  File "/home/conda/feedstock_root/build_artifacts/gplately_1699874743383/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.11/site-packages/gplately/grids.py", line 40, in <module>
    from .reconstruction import PlateReconstruction as _PlateReconstruction
  File "/home/conda/feedstock_root/build_artifacts/gplately_1699874743383/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.11/site-packages/gplately/reconstruction.py", line 11, in <module>
    from . import ptt
ImportError: cannot import name 'ptt' from partially initialized module 'gplately' (most likely due to a circular import) (/home/conda/feedstock_root/build_artifacts/gplately_1699874743383/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.11/site-packages/gplately/__init__.py)
WARNING: Tests failed for gplately-1.2.1-pyhd8ed1ab_0.conda - moving package to /home/conda/feedstock_root/build_artifacts/broken
TESTS FAILED: gplately-1.2.1-pyhd8ed1ab_0.conda
##[error]Bash exited with code '1'.
```