### PR TITLE
Use spherical interpolation for gridding with `tools.griddata_sphere`

### DIFF
--- a/gplately/grids.py
+++ b/gplately/grids.py
@@ -39,6 +39,7 @@ from scipy.interpolate import griddata
 from .geometry import pygplates_to_shapely
 from .reconstruction import PlateReconstruction as _PlateReconstruction
 from .tools import _deg2pixels
+from .tools import griddata_sphere
 
 __all__ = [
     "fill_raster",
@@ -2194,7 +2195,7 @@ class Raster(object):
 
         # Interpolate lons, lats and zvals over a regular grid using nearest
         # neighbour interpolation
-        Z = griddata((out_lon, out_lat), zdata, (X, Y), method='nearest')
+        Z = griddata_sphere((out_lon, out_lat), zdata, (X, Y), method='nearest')
 
         # Write output grid to netCDF if requested.
         if output_name:

--- a/gplately/oceans.py
+++ b/gplately/oceans.py
@@ -112,7 +112,6 @@ import warnings
 import numpy as np
 import pandas as pd
 import pygplates
-from scipy.interpolate import griddata
 
 from . import grids, ptt, reconstruction, tools
 from .ptt import separate_ridge_transform_segments
@@ -1564,7 +1563,7 @@ def _lat_lon_z_to_netCDF_time(
 
     # Interpolate lons, lats and zvals over a regular grid using nearest
     # neighbour interpolation
-    Z = griddata((lons, lats), zdata, (X, Y), method="nearest")
+    Z = tools.griddata_sphere((lons, lats), zdata, (X, Y), method="nearest")
 
     # Access continental grids from the save directory
     if continent_mask_filename is None:

--- a/gplately/reconstruction.py
+++ b/gplately/reconstruction.py
@@ -1884,6 +1884,102 @@ class Points(object):
                 "Cannot save to specified file type. Use csv, gpml, or xls file extension."
             )
 
+    def rotate_reference_frames(
+        self,
+        reconstruction_time,
+        from_rotation_features_or_model=None,  # filename(s), or pyGPlates feature(s)/collection(s) or a RotationModel
+        to_rotation_features_or_model=None,    # filename(s), or pyGPlates feature(s)/collection(s) or a RotationModel
+        from_rotation_reference_plate=0,
+        to_rotation_reference_plate=0,
+        non_reference_plate=701,
+        output_name=None,
+        return_array=False,
+    ):
+        """Rotate a grid defined in one plate model reference frame 
+        within a gplately.Raster object to another plate 
+        reconstruction model reference frame.
+
+        Parameters
+        ----------
+        reconstruction_time : float
+            The time at which to rotate the reconstructed points.
+        from_rotation_features_or_model : str, list of str, or instance of `pygplates.RotationModel`
+            A filename, or a list of filenames, or a pyGPlates 
+            RotationModel object that defines the rotation model
+            that the input grid is currently associated with.
+            `self.plate_reconstruction.rotation_model` is default.
+        to_rotation_features_or_model : str, list of str, or instance of `pygplates.RotationModel`
+            A filename, or a list of filenames, or a pyGPlates 
+            RotationModel object that defines the rotation model
+            that the input grid shall be rotated with.
+            `self.plate_reconstruction.rotation_model` is default.
+        from_rotation_reference_plate : int, default = 0
+            The current reference plate for the plate model the points
+            are defined in. Defaults to the anchor plate 0.
+        to_rotation_reference_plate : int, default = 0
+            The desired reference plate for the plate model the points
+            to be rotated to. Defaults to the anchor plate 0.
+        non_reference_plate : int, default = 701
+            An arbitrary placeholder reference frame with which 
+            to define the "from" and "to" reference frames.
+        output_name : str, default None
+            If passed, the rotated points are saved as a gpml to this filename.
+
+        Returns
+        -------
+        gplately.Points()
+            An instance of the gplately.Points object containing the rotated points.
+        """
+
+        if from_rotation_features_or_model is None:
+            from_rotation_features_or_model = self.plate_reconstruction.rotation_model
+        if to_rotation_features_or_model is None:
+            to_rotation_features_or_model = self.plate_reconstruction.rotation_model
+
+
+        # Create the pygplates.FiniteRotation that rotates 
+        # between the two reference frames.
+        from_rotation_model = pygplates.RotationModel(
+            from_rotation_features_or_model
+        )
+        to_rotation_model = pygplates.RotationModel(
+            to_rotation_features_or_model
+        )
+        from_rotation = from_rotation_model.get_rotation(
+            reconstruction_time, 
+            non_reference_plate, 
+            anchor_plate_id=from_rotation_reference_plate
+        )
+        to_rotation = to_rotation_model.get_rotation(
+            reconstruction_time, 
+            non_reference_plate, 
+            anchor_plate_id=to_rotation_reference_plate
+        )
+        reference_frame_conversion_rotation = to_rotation * from_rotation.get_inverse()
+
+        # reconstruct points to reconstruction_time
+        lons, lats = self.reconstruct(
+            reconstruction_time,
+            anchor_plate_id=from_rotation_reference_plate,
+            return_array=True)
+
+        # convert FeatureCollection to MultiPointOnSphere
+        input_points = pygplates.MultiPointOnSphere((lat, lon) for lon, lat in zip(lons, lats))
+
+        # Rotate grid nodes to the other reference frame
+        output_points = reference_frame_conversion_rotation * input_points
+
+        # Assemble rotated points with grid values.
+        out_lon = np.empty_like(self.lons)
+        out_lat = np.empty_like(self.lats)
+        for i, point in enumerate(output_points):
+            out_lat[i], out_lon[i] = point.to_lat_lon()
+
+        if return_array:
+            return out_lon, out_lat
+        else:
+            return Points(model, out_lon, out_lat, time=reconstruction_time, plate_id=self.plate_id)
+
 
 # FROM RECONSTRUCT_BY_TOPOLOGIES.PY
 class _DefaultCollision(object):

--- a/gplately/tools.py
+++ b/gplately/tools.py
@@ -594,8 +594,8 @@ def griddata_sphere(points, values, xi, method='nearest', **kwargs):
     lats = points[:,1]
 
     # convert to Cartesian coordinates on the unit sphere
-    x0, y0, z0 = gplately.tools.lonlat2xyz(lons, lats, degrees=True)
-    x1, y1, z1 = gplately.tools.lonlat2xyz(xi[0], xi[1])
+    x0, y0, z0 = lonlat2xyz(lons, lats, degrees=True)
+    x1, y1, z1 = lonlat2xyz(xi[0], xi[1])
 
     input_coords = np.c_[x0, y0, z0]
     output_coords = np.c_[x1.ravel(), y1.ravel(), z1.ravel()]

--- a/gplately/tools.py
+++ b/gplately/tools.py
@@ -586,6 +586,9 @@ def griddata_sphere(points, values, xi, method='nearest', **kwargs):
     """
 
     assert xi[0].shape == xi[1].shape, "ensure coordinates in xi are the same shape"
+
+    from scipy.interpolate.interpnd import _ndim_coords_from_arrays
+    points = _ndim_coords_from_arrays(points)
     
     lons = points[:,0]
     lats = points[:,1]

--- a/tests-dir/pytestcases/test_2_points.py
+++ b/tests-dir/pytestcases/test_2_points.py
@@ -50,3 +50,6 @@ def test_pickle_Points(gpts):
     gpts.add_attributes(FROMAGE=attr, TOAGE=attr)
     gpts_dump = pickle.dumps(gpts)
     gpts_load = pickle.loads(gpts_dump)
+
+def test_change_ancbor_plate(gpts):
+    gpts.rotate_reference_frame(50, from_rotation_reference_plate=0, to_rotation_reference_plate=101)


### PR DESCRIPTION
New function at `gplately.tools.griddata_sphere` which transforms input points to Cartesian coordinates on the unit sphere before interpolating to a regular lat/lon grid. Two methods are currently available:

- `nearest` - which applies nearest neighbour interpolation (default)
- `rbf` - which applies a radial basis function

__The rbf returns very good results.__ In the future we should switch to this interpolation method by default. I have hardcoded `neighbors=12` on initialisation of the `RBFInterpolator` object from scipy to improve performance, but this can be overridden by supplying kwargs to the `griddata_sphere` object.