### PR TITLE
Allow RotationModel constructor to copy a model

### DIFF
--- a/gplately/pygplates.py
+++ b/gplately/pygplates.py
@@ -23,16 +23,29 @@ class RotationModel(_pygplates.RotationModel):
         extend_total_reconstruction_poles_to_distant_past=False,
         default_anchor_plate_id=0,
     ):
-        super(RotationModel, self).__init__(
-            rotation_features,
-            reconstruction_tree_cache_size=reconstruction_tree_cache_size,
-            extend_total_reconstruction_poles_to_distant_past=extend_total_reconstruction_poles_to_distant_past,
-            default_anchor_plate_id=default_anchor_plate_id,
-        )
+        # N.B. if rotation_features is a RotationModel, the constructor
+        # will not accept 'extend_total_reconstruction_poles_to_distant_past'
+        # as an argument
+        if isinstance(rotation_features, _pygplates.RotationModel):
+            super(RotationModel, self).__init__(
+                rotation_features,
+                reconstruction_tree_cache_size=reconstruction_tree_cache_size,
+                default_anchor_plate_id=default_anchor_plate_id,
+            )
+        else:
+            super(RotationModel, self).__init__(
+                rotation_features,
+                reconstruction_tree_cache_size=reconstruction_tree_cache_size,
+                extend_total_reconstruction_poles_to_distant_past=extend_total_reconstruction_poles_to_distant_past,
+                default_anchor_plate_id=default_anchor_plate_id,
+            )
 
         if isinstance(rotation_features, str):
             self._filenames = [rotation_features]
-        elif all(isinstance(f, str) for f in rotation_features):
+        elif (
+            hasattr(rotation_features, "__iter__")
+            and all(isinstance(f, str) for f in rotation_features)
+        ):
             self._filenames = list(rotation_features)
         else:
             self._filenames = []

--- a/tests-dir/pytestcases/test_1_reconstructions.py
+++ b/tests-dir/pytestcases/test_1_reconstructions.py
@@ -187,3 +187,11 @@ def test_pickle_Points():
     model_dump = pickle.dumps(model)
     model_load = pickle.loads(model_dump)
     logger.info("Testing test_pickle_Points")
+
+
+def test_rotation_model_copy(model):
+    rot_model = model.rotation_model
+    rot_model_copy = gplately.pygplates.RotationModel(rot_model)
+    rot1 = rot_model.get_rotation(50, 101)
+    rot2 = rot_model_copy.get_rotation(50, 101)
+    assert rot1 == rot2


### PR DESCRIPTION
Modify `gplately.pygplates.RotationModel` constructor so it accepts another instance of `pygplates.RotationModel` or `gplately.pygplates.RotatioModel` as input.
Also add a test to `test_1_reconstructions.py` (`test_rotation_model_copy`) to cover this functionality.

Would fix #180 