### PR TITLE
Ensure `_load_FeatureCollection` correctly assigns `filenames` attribute

### DIFF
--- a/gplately/gpml.py
+++ b/gplately/gpml.py
@@ -265,9 +265,10 @@ def _load_FeatureCollection(geometry):
         fc = _FeatureCollection()
         for geom in geometry:
             fc.add( _FeatureCollection(geom) )
+        fc.filenames = list(geometry)
         return fc
     elif _is_string(geometry):
-        return _FeatureCollection(geometry)
+        return _FeatureCollection(geometry, filenames=[geometry])
     elif geometry is None:
         return None
     else:

--- a/tests-dir/pytestcases/test_1_reconstructions.py
+++ b/tests-dir/pytestcases/test_1_reconstructions.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import pickle
 
 import numpy as np
 import pytest
@@ -182,8 +184,6 @@ def test_point_velocities(time, model):
 
 
 def test_pickle_Points():
-    import pickle
-
     model_dump = pickle.dumps(model)
     model_load = pickle.loads(model_dump)
     logger.info("Testing test_pickle_Points")
@@ -195,3 +195,15 @@ def test_rotation_model_copy(model):
     rot1 = rot_model.get_rotation(50, 101)
     rot2 = rot_model_copy.get_rotation(50, 101)
     assert rot1 == rot2
+
+
+def test_reconstruction_filenames(model):
+    assert (
+        "Muller_etal_2019_PlateBoundaries_DeformingNetworks.gpmlz"
+        in [os.path.basename(i) for i in model.topology_features.filenames]
+    )
+
+
+def test_pickle_reconstruction(model):
+    pickled = pickle.loads(pickle.dumps(model))
+    assert len(model.topology_features) == len(pickled.topology_features)


### PR DESCRIPTION
This PR resolves #185. 

The code snippet from that issue:
```
import pickle
from gplately import PlateReconstruction
from plate_model_manager import PlateModelManager

pmm = PlateModelManager()
model = pmm.get_model("Muller2019")
plate_reconstruction = PlateReconstruction(
    rotation_model=model.get_rotation_model(),
    topology_features=model.get_layer("Topologies"),
)
pickled = pickle.loads(pickle.dumps(plate_reconstruction))
print(f"Original num. features: {len(plate_reconstruction.topology_features)}")
print(f"Pickled num. features: {len(pickled.topology_features)}")
```
now produces the correct output:
```
Original num. features: 7941
Pickled num. features: 7941
```