### PR TITLE
remove default font setting from two notebooks

### DIFF
--- a/Notebooks/07-WorkingWithPlateTectonicStats.ipynb
+++ b/Notebooks/07-WorkingWithPlateTectonicStats.ipynb
@@ -289,7 +289,6 @@
     "\n",
     "# Plotting functions\n",
     "fig = plt.figure(figsize=(8, 4), dpi=200)\n",
-    "plt.rcParams['font.family'] = 'Arial'\n",
     "ax1 = fig.add_subplot(111, xlim=(250,0), ylim=(0,18), xlabel='Age (Ma)', ylabel=\"Rate (cm/yr)\",\n",
     "                      title=\"Subduction zone convergence and ridge spreading rates (cm/yr):\\nMüller et al 2019\")\n",
     "\n",
@@ -476,7 +475,6 @@
    "source": [
     "fig, axes = plt.subplots(2, 1, figsize=(8,6), dpi=200)\n",
     "fig.subplots_adjust(hspace=0.05)\n",
-    "plt.rcParams['font.family'] = 'Arial'\n",
     "n_axes = len(axes)\n",
     "\n",
     "# Access subduction zone and ridge lengths from pandas dataframes\n",
@@ -553,7 +551,6 @@
    "source": [
     "fig, axes = plt.subplots(2, 1, figsize=(8,6), dpi=200)\n",
     "fig.subplots_adjust(hspace=0.05)\n",
-    "plt.rcParams['font.family'] = 'Arial'\n",
     "n_axes = len(axes)\n",
     "\n",
     "# Access subduction convergence and ridge spreading rates (along with their standard deviation) from the dataframes\n",
@@ -668,7 +665,6 @@
    "source": [
     "fig, axes = plt.subplots(2, 1, figsize=(8,6), dpi=200)\n",
     "fig.subplots_adjust(hspace=0.05)\n",
-    "plt.rcParams['font.family'] = 'Arial'\n",
     "n_axes = len(axes)\n",
     "\n",
     "\n",
@@ -749,7 +745,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
removed "plt.rcParams['font.family'] = 'Arial'" from

- Notebooks/07-WorkingWithPlateTectonicStats.ipynb
- Notebooks/09-CreatingMotionPathsAndFlowlines.ipynb