### PR TITLE
SciPy 1.15 renamed interpnd to _interpnd.

### DIFF
--- a/gplately/grids.py
+++ b/gplately/grids.py
@@ -612,7 +612,11 @@ class RegularGridInterpolator(_RGI):
             return output_tuple[0]
 
     def _prepare_xi(self, xi):
-        from scipy.interpolate.interpnd import _ndim_coords_from_arrays
+        try:
+            from scipy.interpolate.interpnd import _ndim_coords_from_arrays
+        except ImportError:
+            # SciPy 1.15 renamed interpnd to _interpnd (see https://github.com/scipy/scipy/pull/21754).
+            from scipy.interpolate._interpnd import _ndim_coords_from_arrays
 
         ndim = len(self.grid)
         xi = _ndim_coords_from_arrays(xi, ndim=ndim)

--- a/gplately/tools.py
+++ b/gplately/tools.py
@@ -554,7 +554,11 @@ def griddata_sphere(points, values, xi, method="nearest", **kwargs):
 
     assert xi[0].shape == xi[1].shape, "ensure coordinates in xi are the same shape"
 
-    from scipy.interpolate.interpnd import _ndim_coords_from_arrays
+    try:
+        from scipy.interpolate.interpnd import _ndim_coords_from_arrays
+    except ImportError:
+        # SciPy 1.15 renamed interpnd to _interpnd (see https://github.com/scipy/scipy/pull/21754).
+        from scipy.interpolate._interpnd import _ndim_coords_from_arrays
 
     points = _ndim_coords_from_arrays(points)
 


### PR DESCRIPTION
Fixes failed merge in #304 related to issue #303 (only just recently did SciPy 1.15 get released, and cause the merge to fail).

Fixes error:
ImportError: cannot import name '_ndim_coords_from_arrays' from 'scipy.interpolate.interpnd'

See https://github.com/scipy/scipy/pull/21754
