### PR TITLE
Require pyGPlates 1.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Auto detect text files and store as LF in repository.
+* text=auto
+
+# Isolate binary files in case auto-detection algorithm fails.
+# These are extensions of binary files that exist in repository.
+*.{icns,ico,gz,dbf,shp,shx,png} binary
+
+*.sh text eol=lf

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
           init-shell: >-
             bash
             powershell
-          cache-environment: false
+          cache-environment: true
           post-cleanup: "all"
 
       - name: Install current gplately

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,6 +28,12 @@ jobs:
         
     if: github.event.pull_request.draft == false
     steps:
+      # Used with 'cache-environment-key'.
+      # See https://github.com/mamba-org/setup-micromamba?tab=readme-ov-file#caching
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+      
       - uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
         with:
@@ -39,6 +45,9 @@ jobs:
             bash
             powershell
           cache-environment: true
+          # Cache only on the same day.
+          # See https://github.com/mamba-org/setup-micromamba?tab=readme-ov-file#caching
+          cache-environment-key: environment-${{ steps.date.outputs.date }}
           post-cleanup: "all"
 
       - name: Install current gplately

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
           init-shell: >-
             bash
             powershell
-          cache-environment: true
+          cache-environment: false
           post-cleanup: "all"
 
       - name: Install current gplately

--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -1,4 +1,8 @@
 # Can source pyGPlates from its 'rc' channel or main channel.
+# Note: The min. pygplates requirement (in meta.yaml) should find
+#       the right channel (eg, >=1.0.0 should use main channel when
+#       1.0.0rc1 is in 'rc' channel and 1.0.0 is in main channel).
+#
 # Other dependencies are sourced from main channel.
 channel_sources:
   - conda-forge/label/pygplates_rc,conda-forge

--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -1,7 +1,4 @@
-# Note: This will go into the 'recipe' directory of
-#       https://github.com/conda-forge/gplately-feedstock
-#       in order to use pygplates-1.0.0rc1 (which is in a different channel).
-#       Although probably won't be necessary to add (to feedstock) because pygplates-1.0.0
-#       (main channel) will be out soon (Jan 2025), and GPlately 2.0 can just use that.
+# Can source pyGPlates from its 'rc' channel or main channel.
+# Other dependencies are sourced from main channel.
 channel_sources:
   - conda-forge/label/pygplates_rc,conda-forge

--- a/conda/doc-env.yml
+++ b/conda/doc-env.yml
@@ -1,6 +1,5 @@
 name: doc-env
 channels:
-  - conda-forge/label/pygplates_rc
   - conda-forge
   - defaults
 dependencies:

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - numpy >=1.16.0
     - scipy >=1.0.0
-    - pygplates >= 1.0.0rc1
+    - pygplates >= 1.0.0
     - shapely
     - matplotlib-base
     - cartopy

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -1,6 +1,5 @@
 name: base
 channels:
-  - conda-forge/label/pygplates_rc
   - conda-forge
 dependencies:
   - python=3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pyyaml",
     "pygmt",
     "rioxarray",
-    "pygplates>=1.0.0rc1",
+    "pygplates>=1.0.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 keywords = ["Tectonics", "Earth"]
 dependencies = [
-    "numpy>=1.16.0",
+    "numpy>=1.16.0,<2.0a0",  # Temporary until stripy is compiled to support NumPy 2.x (see https://github.com/GPlates/gplately/issues/305)
     "scipy>=1.0.0",
     "shapely",
     "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
             "pyyaml",
             "pygmt",
             "rioxarray",
-            "pygplates>=1.0.0rc1",
+            "pygplates>=1.0.0",
         ],
         packages=["gplately"],
         # package_data={

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
         long_description=long_description,
         long_description_content_type="text/markdown",
         install_requires=[
-            "numpy>=1.16.0",
+            "numpy>=1.16.0,<2.0a0",  # Temporary until stripy is compiled to support NumPy 2.x (see https://github.com/GPlates/gplately/issues/305)
             "scipy>=1.0.0",
             "shapely",
             "matplotlib",

--- a/tests-dir/test-env.yml
+++ b/tests-dir/test-env.yml
@@ -1,6 +1,5 @@
 name: test-env
 channels:
-  - conda-forge/label/pygplates_rc
   - conda-forge
   - defaults
 dependencies:


### PR DESCRIPTION
This updates use of pyGPlates from `1.0.0rc1` to `1.0.0` (now released on conda and pip).

- Closes #223
   - Since pyGPlates `1.0.0` now pickles "uninterpreted" property values (not handled by `1.0.0rc1`).
- Fixes #270
   - By using [pygplates.PlateBoundaryStatistic.boundary_feature](https://www.gplates.org/docs/pygplates/generated/pygplates.plateboundarystatistic#pygplates.PlateBoundaryStatistic.boundary_feature) introduced in pygplates `1.0.0` (not in `1.0.0rc1`).
 - Closes #305
    - By restricting *runtime* NumPy dependency to `numpy<2.0` (in "pyproject.toml" and "setup.py").
    - Because, while pygplates `1.0.0` is compiled to support NumPy 2.x (and 1.x) on conda and pip, `stripy` is compiled only for conda (I think).
    - See underworldcode/stripy#114
    - When that's fixed we can relax the restriction again.